### PR TITLE
Fix Jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
     }
     post {
         always {
-            sh 'docker-compose -f docker/compose/docker-compose.yaml down'
+            sh 'docker-compose -f docker/compose/run-lint.yaml down'
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,12 +77,13 @@ pipeline {
 
         stage("Run lint") {
             steps {
-                sh 'docker-compose -f docker/compose/run-lint.yaml up --build --abort-on-container-exit --exit-code-from lint-libsawtooth"'
+                sh 'docker-compose -f docker/compose/run-lint.yaml up --build --abort-on-container-exit --exit-code-from lint-libsawtooth'
             }
         }
     }
     post {
-    always {
-        sh 'docker-compose -f docker/compose/docker-compose.yaml down'
+        always {
+            sh 'docker-compose -f docker/compose/docker-compose.yaml down'
+        }
     }
 }


### PR DESCRIPTION
Poor formatting was obscuring a missing curly brace, which causes
builds to fail.

Signed-off-by: Ryan Beck-Buysse <rbuysse@bitwise.io>