### PR TITLE
Rework ChainController so it does not require "light_clone"

### DIFF
--- a/libsawtooth/src/journal/block_scheduler.rs
+++ b/libsawtooth/src/journal/block_scheduler.rs
@@ -91,18 +91,22 @@ impl<B: BlockStatusStore> BlockSchedulerState<B> {
 
             if self.processing.contains(block.header().previous_block_id()) {
                 debug!(
-                    "During block scheduling, previous block {} in process, adding block {} to pending",
+                    "During block scheduling, previous block {} in process, adding block {} to \
+                        pending",
                     block.header().previous_block_id(),
-                    block.block().header_signature());
+                    block.block().header_signature()
+                );
                 self.add_block_to_pending(block);
                 continue;
             }
 
             if self.pending.contains(block.header().previous_block_id()) {
                 debug!(
-                    "During block scheduling, previous block {} is pending, adding block {} to pending",
+                    "During block scheduling, previous block {} is pending, adding block {} to \
+                        pending",
                     block.header().previous_block_id(),
-                    block.block().header_signature());
+                    block.block().header_signature()
+                );
 
                 self.add_block_to_pending(block);
                 continue;
@@ -112,12 +116,19 @@ impl<B: BlockStatusStore> BlockSchedulerState<B> {
                 && self.block_validity(block.header().previous_block_id()) == BlockStatus::Unknown
             {
                 info!(
-                    "During block scheduling, predecessor of block {}, {}, status is unknown. Scheduling all blocks since last predecessor with known status",
-                    block.block().header_signature(), block.header().previous_block_id());
+                    "During block scheduling, predecessor of block {}, {}, status is unknown. \
+                        Scheduling all blocks since last predecessor with known status",
+                    block.block().header_signature(),
+                    block.header().previous_block_id()
+                );
 
-                let blocks_previous_to_previous = self.block_manager
-                        .branch(block.header().previous_block_id())
-                        .expect("Block id of block previous to block being scheduled is unknown to the block manager");
+                let blocks_previous_to_previous = self
+                    .block_manager
+                    .branch(block.header().previous_block_id())
+                    .expect(
+                        "Block id of block previous to block being scheduled is unknown \
+                        to the block manager",
+                    );
                 self.add_block_to_pending(block);
 
                 let mut to_be_scheduled = vec![];

--- a/libsawtooth/src/journal/block_validator.rs
+++ b/libsawtooth/src/journal/block_validator.rs
@@ -666,29 +666,46 @@ impl BlockValidation for PermissionValidation {
     ) -> Result<(), ValidationError> {
         if block.header().block_num() != 0 {
             let state_root = prev_state_root.ok_or_else(|| {
-                ValidationError::BlockValidationError(
-                        format!("During permission check of block {} block_num is {} but missing a previous state root",
-                            block.block().header_signature(), block.header().block_num()))
+                ValidationError::BlockValidationError(format!(
+                    "During permission check of block {} block_num is {} but missing a\
+                            previous state root",
+                    block.block().header_signature(),
+                    block.header().block_num()
+                ))
             })?;
 
-            let identity_view: IdentityView = self.state_view_factory.create_view(state_root)
+            let identity_view: IdentityView = self
+                .state_view_factory
+                .create_view(state_root)
                 .map_err(|err| {
-                ValidationError::BlockValidationError(
-                        format!("During permission check of block ({}, {}) state root was not found in state: {}",
-                            block.block().header_signature(), block.header().block_num(), err))
-            })?;
+                    ValidationError::BlockValidationError(format!(
+                        "During permission check of block ({}, {}) state root was not \
+                            found in state: {}",
+                        block.block().header_signature(),
+                        block.header().block_num(),
+                        err
+                    ))
+                })?;
             let permission_verifier = PermissionVerifier::new(Box::new(identity_view));
             for batch in block.block().batches() {
-                let authorized = permission_verifier.is_batch_signer_authorized(batch).map_err(|err| {
-                ValidationError::BlockValidationError(
-                        format!("During permission check of block ({}, {}), unable to read permissions: {}",
-                            block.block().header_signature(), block.header().block_num(), err))
+                let authorized = permission_verifier
+                    .is_batch_signer_authorized(batch)
+                    .map_err(|err| {
+                        ValidationError::BlockValidationError(format!(
+                            "During permission check of block ({}, {}), unable to read \
+                        permissions: {}",
+                            block.block().header_signature(),
+                            block.header().block_num(),
+                            err
+                        ))
                     })?;
                 if !authorized {
-                    return Err(ValidationError::BlockValidationFailure(
-                            format!("Block {} failed permission verification: batch {} signer is not authorized",
-                            block.block().header_signature(),
-                            batch.header_signature())));
+                    return Err(ValidationError::BlockValidationFailure(format!(
+                        "Block {} failed permission verification: batch {} signer is \
+                            not authorized",
+                        block.block().header_signature(),
+                        batch.header_signature()
+                    )));
                 }
             }
         }
@@ -716,10 +733,12 @@ impl BlockValidation for OnChainRulesValidation {
     ) -> Result<(), ValidationError> {
         if block.header().block_num() != 0 {
             let state_root = prev_state_root.ok_or_else(|| {
-                ValidationError::BlockValidationError(
-                        format!("During check of on-chain rules for block {}, block num was {}, but missing a previous state root",
-                            block.block().header_signature(),
-                            block.header().block_num()))
+                ValidationError::BlockValidationError(format!(
+                    "During check of on-chain rules for block {}, block num was {}, \
+                            but missing a previous state root",
+                    block.block().header_signature(),
+                    block.header().block_num()
+                ))
             })?;
             let settings_view: SettingsView =
                 self.view_factory.create_view(state_root).map_err(|err| {

--- a/libsawtooth/src/journal/chain.rs
+++ b/libsawtooth/src/journal/chain.rs
@@ -252,13 +252,11 @@ pub struct ChainController<TEP: ExecutionPlatform + Clone> {
     consensus_notifier: Arc<dyn ConsensusNotifier>,
     consensus_registry: Arc<dyn ConsensusRegistry>,
     state_view_factory: StateViewFactory,
-    block_validator: BlockValidator<TEP>,
+    block_validator: Option<BlockValidator<TEP>>,
     block_validation_results: BlockValidationResultStore,
 
-    // Queues
-    block_queue_sender: Option<Sender<String>>,
-    commit_queue_sender: Option<Sender<BlockPair>>,
-    validation_result_sender: Option<Sender<BlockValidationResult>>,
+    // Request Queue
+    request_sender: Option<Sender<ChainControllerRequest>>,
 
     state_pruning_block_depth: u32,
     chain_head_lock: ChainHeadLock,
@@ -292,12 +290,10 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
                 state_pruning_manager,
                 fork_cache: ForkCache::new(fork_cache_keep_time),
             })),
-            block_validator,
+            block_validator: Some(block_validator),
             block_validation_results,
             stop_handle: Arc::new(Mutex::new(None)),
-            block_queue_sender: None,
-            commit_queue_sender: None,
-            validation_result_sender: None,
+            request_sender: None,
             state_pruning_block_depth,
             chain_head_lock,
             consensus_notifier: Arc::from(consensus_notifier),
@@ -346,184 +342,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
         })
     }
 
-    /// This is used by a non-genesis journal when it has received the
-    /// genesis block from the genesis validator
-    fn set_genesis(
-        &self,
-        state: &mut ChainControllerState,
-        lock: &ChainHeadLock,
-        block: &BlockPair,
-    ) -> Result<(), ChainControllerError> {
-        if block.header().previous_block_id() == NULL_BLOCK_IDENTIFIER {
-            let chain_id = state.chain_id_manager.get_block_chain_id()?;
-            if chain_id
-                .as_ref()
-                .map(|block_id| block_id != block.block().header_signature())
-                .unwrap_or(false)
-            {
-                warn!(
-                    "Block id does not match block chain id {}. Ignoring initial chain head: {}",
-                    chain_id.unwrap(),
-                    block.block().header_signature()
-                );
-            } else {
-                self.block_validator.validate_block(&block)?;
-
-                if chain_id.is_none() {
-                    state
-                        .chain_id_manager
-                        .save_block_chain_id(block.block().header_signature())?;
-                }
-
-                state
-                    .block_manager
-                    .persist(block.block().header_signature(), COMMIT_STORE)?;
-
-                // Create Ref-C: External reference for the chain head will be held until it is
-                // superceded by a new chain head.
-                state.chain_head = Some(
-                    state
-                        .block_manager
-                        .ref_block(block.block().header_signature())?,
-                );
-
-                match self
-                    .block_validation_results
-                    .get(block.block().header_signature())
-                {
-                    Some(validation_results) => {
-                        let receipts: Vec<TransactionReceipt> = validation_results
-                            .execution_results
-                            .iter()
-                            .map(TransactionReceipt::from)
-                            .collect();
-                        for observer in &mut state.observers {
-                            observer.chain_update(&block, receipts.as_slice());
-                        }
-                    }
-                    None => {
-                        error!(
-                            "While committing {}, found block missing execution results",
-                            block.block(),
-                        );
-                    }
-                }
-
-                let mut guard = lock.acquire();
-                guard.notify_on_chain_updated(block.clone(), vec![], vec![]);
-            }
-        }
-
-        Ok(())
-    }
-
-    pub fn on_block_received(&mut self, block_id: &str) -> Result<(), ChainControllerError> {
-        // Only need a read lock to check duplicates, but need to upgrade to write lock for
-        // updating chain head.
-        {
-            let mut state = self
-                .state
-                .write()
-                .expect("No lock holder should have poisoned the lock");
-
-            if state.chain_head.is_none() {
-                if let Some(Some(block)) = state.block_manager.get(&[&block_id]).next() {
-                    if let Err(err) = self.set_genesis(&mut state, &self.chain_head_lock, &block) {
-                        warn!(
-                            "Unable to set chain head; genesis block {} is not valid: {:?}",
-                            block.block().header_signature(),
-                            err
-                        );
-                    }
-                } else {
-                    warn!("Received block not in block manager");
-                }
-                return Ok(());
-            }
-        }
-
-        let block = {
-            let mut state = self
-                .state
-                .write()
-                .expect("No lock holder should have poisoned the lock");
-
-            if let Some(Some(block)) = state.block_manager.get(&[&block_id]).next() {
-                // Create Ref-C: Hold this reference until consensus renders a {commit, ignore, or
-                // fail} opinion on the block.
-                match state.block_manager.ref_block(&block_id) {
-                    Ok(block_ref) => {
-                        state
-                            .block_references
-                            .insert(block_ref.block_id().to_owned(), block_ref);
-                        self.consensus_notifier.notify_block_new(&block);
-                        Some(block)
-                    }
-                    Err(err) => {
-                        error!(
-                            "Unable to ref block {} received from completer; ignoring: {:?}",
-                            &block_id, err
-                        );
-                        None
-                    }
-                }
-            } else {
-                warn!(
-                    "Received block id for block not in block manager: {}",
-                    block_id
-                );
-                None
-            }
-        };
-
-        if let Some(block) = block {
-            let mut state = self
-                .state
-                .write()
-                .expect("No lock holder should have poisoned the lock");
-
-            // Transfer Ref-B: Implicitly transfer ownership of the external reference placed on
-            // this block by the completer. The ForkCache is now responsible for unrefing the block
-            // when it expires. This happens when either 1) the block is replaced in the cache by
-            // another block which extends it, at which point this block will have an int. ref.
-            // count of at least 1, or 2) the fork becomes inactive the block is purged, at which
-            // point the block may be dropped if no other ext. ref's exist.
-            if let Some(previous_block_id) = state
-                .fork_cache
-                .insert(&block_id, Some(block.header().previous_block_id()))
-            {
-                // Drop Ref-B: This fork was extended and so this block has an int. ref. count of
-                // at least one, so we can drop the ext. ref. placed on the block to keep the fork
-                // around.
-                match state.block_manager.unref_block(&previous_block_id) {
-                    Ok(true) => {
-                        panic!(
-                            "Block {:?} was unref'ed because it was the head of a fork that was
-                            just extended. The unref caused the block to drop, but it should have
-                            had an internal reference count of at least 1.",
-                            previous_block_id,
-                        );
-                    }
-                    Ok(false) => (),
-                    Err(err) => error!(
-                        "Failed to unref expired block {}: {:?}",
-                        previous_block_id, err
-                    ),
-                }
-            }
-
-            for block_id in state.fork_cache.purge() {
-                // Drop Ref-B: The fork is no longer active, and we have to drop the ext. ref.
-                // placed on the block to keep the fork around.
-                if let Err(err) = state.block_manager.unref_block(&block_id) {
-                    error!("Failed to unref expired block {}: {:?}", block_id, err);
-                }
-            }
-        }
-
-        Ok(())
-    }
-
     pub fn validate_block(&self, block: &BlockPair) {
         // If there is already a result for this block, no need to validate it
         if self
@@ -534,20 +352,37 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
             return;
         }
 
-        // Create block validation result, maked as in-validation
-        self.block_validation_results.insert(BlockValidationResult {
-            block_id: block.block().header_signature().to_string(),
-            execution_results: vec![],
-            num_transactions: 0,
-            status: BlockStatus::InValidation,
-        });
+        if self.request_sender.is_some() {
+            // Create block validation result, marked as in-validation
+            self.block_validation_results.insert(BlockValidationResult {
+                block_id: block.block().header_signature().to_string(),
+                execution_results: vec![],
+                num_transactions: 0,
+                status: BlockStatus::InValidation,
+            });
 
-        // Submit for validation
-        let sender = self.validation_result_sender.as_ref().expect(
-            "Attempted to submit block for validation before starting the chain controller",
-        );
-        self.block_validator
-            .submit_blocks_for_verification(&[block.clone()], &sender);
+            // Submit for validation
+            let sender = self.request_sender.as_ref().expect(
+                "Attempted to submit block for validation before starting the chain controller",
+            );
+            if let Err(err) =
+                self.request_sender
+                    .as_ref()
+                    .unwrap()
+                    .send(ChainControllerRequest::ValidateBlock {
+                        blocks: vec![block.clone()],
+                        response_sender: sender.clone(),
+                    })
+            {
+                error!("Unable to submit block for validation: {}", err);
+            }
+        } else {
+            debug!(
+                "Attempting to submit block for validation {} before chain controller is started; \
+                Ignoring",
+                block.block().header_signature()
+            );
+        }
     }
 
     pub fn ignore_block(&self, block: &BlockPair) {
@@ -592,10 +427,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
         }
     }
 
-    fn set_block_validation_result(&self, result: BlockValidationResult) {
-        self.block_validation_results.insert(result)
-    }
-
     fn get_block(&self, block_id: &str) -> Option<BlockPair> {
         let state = self
             .state
@@ -606,8 +437,8 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
     }
 
     pub fn commit_block(&self, block: BlockPair) {
-        if let Some(sender) = self.commit_queue_sender.as_ref() {
-            if let Err(err) = sender.send(block) {
+        if let Some(sender) = self.request_sender.as_ref() {
+            if let Err(err) = sender.send(ChainControllerRequest::CommitBlock(block)) {
                 error!("Unable to add block to block queue: {}", err);
             }
         } else {
@@ -618,266 +449,14 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
         }
     }
 
-    fn on_block_validated(&self, block: &BlockPair, result: &BlockValidationResult) {
-        counter!("chain.ChainController.blocks_considered_count", 1);
-
-        match result.status {
-            BlockStatus::Valid => {
-                // Keep Ref-C: The block has been validated so ownership of the ext. ref. is
-                // maintained. The consensus engine is responsible for rendering an opinion of
-                // either commit, fail, or ignore, at which time the ext. ref. will be accounted
-                // for (moved into chain head in case of commit, dropped otherwise)
-                self.consensus_notifier
-                    .notify_block_valid(block.block().header_signature());
-            }
-            BlockStatus::Invalid => {
-                self.consensus_notifier
-                    .notify_block_invalid(block.block().header_signature());
-
-                let mut state = self
-                    .state
-                    .write()
-                    .expect("No lock holder should have poisoned the lock");
-
-                // Drop Ref-C: The block has been found to be invalid, and we are no longer
-                // interested in it. The invalid result will be cached for a period.
-                if state
-                    .block_references
-                    .remove(block.block().header_signature())
-                    .is_none()
-                {
-                    error!(
-                        "Reference not found for invalid block {}",
-                        block.block().header_signature()
-                    );
-                }
-            }
-            _ => error!(
-                "on_block_validated() called for block {}, but result was {:?}",
-                block.block().header_signature(),
-                result.status,
-            ),
-        }
-
-        match self.notify_block_validation_results_received(block) {
-            Ok(_) => (),
-            Err(err) => warn!("{:?}", err),
-        }
-    }
-
-    fn handle_block_commit(&mut self, block: &BlockPair) -> Result<(), ChainControllerError> {
-        {
-            // only hold this lock as long as the loop is active.
-            let mut state = self
-                .state
-                .write()
-                .expect("No lock holder should have poisoned the lock");
-
-            loop {
-                let chain_head = state
-                    .chain_reader
-                    .chain_head()
-                    .map_err(|err| {
-                        error!("Error reading chain head: {:?}", err);
-                        err
-                    })?
-                    .expect(
-                        "Attempting to handle block commit before a genesis block has been
-                        committed",
-                    );
-                let result = state.build_fork(block, &chain_head).map_err(|err| {
-                    error!(
-                        "Error occured while building fork resolution result: {:?}",
-                        err,
-                    );
-                    err
-                })?;
-
-                let mut chain_head_guard = self.chain_head_lock.acquire();
-                let chain_head_updated = state
-                    .check_chain_head_updated(&chain_head, &block)
-                    .map_err(|err| {
-                        error!(
-                            "Error occured while checking if chain head updated: {:?}",
-                            err,
-                        );
-                        err
-                    })?;
-                if chain_head_updated {
-                    continue;
-                }
-
-                // Move Ref-C: Consensus has decided this block should become the new chain
-                // head, so the ChainController will maintain ownership of this ext. ref until a
-                // new chain head replaces it.
-                state.chain_head = Some(
-                    state
-                        .block_references
-                        .remove(block.block().header_signature())
-                        .ok_or_else(|| {
-                            ChainControllerError::ConsensusError(
-                                "Consensus has already decided on this block".into(),
-                            )
-                        })?,
-                );
-
-                let new_roots = result
-                    .new_chain
-                    .iter()
-                    .map(|block| block.header().state_root_hash())
-                    .collect::<Vec<_>>();
-                let current_roots = result
-                    .current_chain
-                    .iter()
-                    .map(|block| (block.header().block_num(), block.header().state_root_hash()))
-                    .collect::<Vec<_>>();
-                state
-                    .state_pruning_manager
-                    .update_queue(new_roots.as_slice(), current_roots.as_slice());
-
-                state
-                    .block_manager
-                    .persist(block.block().header_signature(), COMMIT_STORE)
-                    .map_err(|err| {
-                        error!("Error persisting new chain head: {:?}", err);
-                        err
-                    })?;
-
-                info!("Chain head updated to {}", block.block());
-
-                self.consensus_notifier
-                    .notify_block_commit(block.block().header_signature());
-
-                counter!(
-                    "chain.ChainController.committed_transactions_count",
-                    result.transaction_count as u64
-                );
-                gauge!(
-                    "chain.ChainController.block_num",
-                    block.header().block_num() as i64
-                );
-
-                chain_head_guard.notify_on_chain_updated(
-                    block.clone(),
-                    result.committed_batches,
-                    result.uncommitted_batches,
-                );
-
-                block.block().batches().iter().for_each(|batch| {
-                    if batch.trace() {
-                        debug!(
-                            "TRACE: {}: ChainController.on_block_validated",
-                            batch.header_signature()
-                        )
-                    }
-                });
-
-                for blk in result.new_chain.iter().rev() {
-                    match self
-                        .block_validation_results
-                        .get(blk.block().header_signature())
-                    {
-                        Some(validation_results) => {
-                            let receipts: Vec<TransactionReceipt> = validation_results
-                                .execution_results
-                                .iter()
-                                .map(TransactionReceipt::from)
-                                .collect();
-                            for observer in &mut state.observers {
-                                observer.chain_update(&block, receipts.as_slice());
-                            }
-                        }
-                        None => {
-                            error!(
-                                "While committing {}, found block {} missing execution results",
-                                block.block(),
-                                blk.block(),
-                            );
-                        }
-                    }
-                }
-
-                let total_committed_txns = match state.chain_reader.count_committed_transactions() {
-                    Ok(count) => count,
-                    Err(err) => {
-                        error!(
-                            "Unable to read total committed transactions count: {:?}",
-                            err
-                        );
-                        0
-                    }
-                };
-
-                gauge!(
-                    "chain.ChainController.committed_transactions_gauge",
-                    total_committed_txns as i64
-                );
-
-                let chain_head_block_num = block.header().block_num();
-                if chain_head_block_num + 1 > u64::from(self.state_pruning_block_depth) {
-                    let prune_at =
-                        chain_head_block_num - (u64::from(self.state_pruning_block_depth));
-                    match state.chain_reader.get_block_by_block_num(prune_at) {
-                        Ok(Some(block)) => state.state_pruning_manager.add_to_queue(
-                            block.header().block_num(),
-                            block.header().state_root_hash(),
-                        ),
-                        Ok(None) => warn!("No block at block height {}; ignoring...", prune_at),
-                        Err(err) => {
-                            error!("Unable to fetch block at height {}: {:?}", prune_at, err)
-                        }
-                    }
-
-                    // Execute pruning:
-                    state.state_pruning_manager.execute(prune_at)
-                }
-
-                // Updated the block, so we're done
-                break;
-            }
-        }
-
-        Ok(())
-    }
-
-    /// Light clone makes a copy of this controller, without access to the stop
-    /// handle.
-    pub fn light_clone(&self) -> Self {
-        ChainController {
-            state: self.state.clone(),
-            // This instance doesn't share the stop handle: it's not a
-            // publicly accessible instance
-            stop_handle: Arc::new(Mutex::new(None)),
-            block_validator: self.block_validator.clone(),
-            block_validation_results: self.block_validation_results.clone(),
-            block_queue_sender: self.block_queue_sender.clone(),
-            commit_queue_sender: self.commit_queue_sender.clone(),
-            validation_result_sender: self.validation_result_sender.clone(),
-            state_pruning_block_depth: self.state_pruning_block_depth,
-            chain_head_lock: self.chain_head_lock.clone(),
-            consensus_notifier: self.consensus_notifier.clone(),
-            consensus_registry: self.consensus_registry.clone(),
-            state_view_factory: self.state_view_factory.clone(),
-        }
-    }
-
-    fn notify_block_validation_results_received(
-        &self,
-        block: &BlockPair,
-    ) -> Result<(), ChainControllerError> {
-        let sender = self
-            .validation_result_sender
-            .as_ref()
-            .expect("Unable to ref validation_result_sender");
-
-        self.block_validator.process_pending(block, &sender);
-        Ok(())
-    }
-
     pub fn queue_block(&self, block_id: &str) {
-        if self.block_queue_sender.is_some() {
-            let sender = self.block_queue_sender.clone();
-            if let Err(err) = sender.as_ref().unwrap().send(block_id.into()) {
+        if self.request_sender.is_some() {
+            if let Err(err) = self
+                .request_sender
+                .as_ref()
+                .unwrap()
+                .send(ChainControllerRequest::QueueBlock(block_id.into()))
+            {
                 error!("Unable to add block to block queue: {}", err);
             }
         } else {
@@ -934,122 +513,38 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
         self.initialize_chain_head();
         let mut stop_handle = self.stop_handle.lock().unwrap();
         if stop_handle.is_none() {
-            let (block_queue_sender, block_queue_receiver) = channel();
-            let (validation_result_sender, validation_result_receiver) = channel();
-            let (commit_queue_sender, commit_queue_receiver) = channel();
+            let (request_sender, request_receiver) = channel();
 
-            self.block_queue_sender = Some(block_queue_sender);
-            self.validation_result_sender = Some(validation_result_sender);
-            self.commit_queue_sender = Some(commit_queue_sender);
+            self.request_sender = Some(request_sender.clone());
 
-            let thread_chain_controller = self.light_clone();
             let exit_flag = Arc::new(AtomicBool::new(false));
+
+            let block_validator = self
+                .block_validator
+                .take()
+                .expect("Unable to take block validator");
+
             let mut chain_thread = ChainThread::new(
-                thread_chain_controller,
-                block_queue_receiver,
+                request_receiver,
                 exit_flag.clone(),
+                self.state.clone(),
+                self.chain_head_lock.clone(),
+                self.consensus_notifier.clone(),
+                self.state_pruning_block_depth,
+                self.block_validation_results.clone(),
+                block_validator,
+                request_sender,
             );
-            *stop_handle = Some(ChainThreadStopHandle::new(exit_flag.clone()));
-            let chain_thread_builder =
-                thread::Builder::new().name("ChainThread:BlockReceiver".into());
+            *stop_handle = Some(ChainThreadStopHandle::new(exit_flag));
+            let chain_thread_builder = thread::Builder::new().name("ChainThread".into());
             chain_thread_builder
                 .spawn(move || {
                     if let Err(err) = chain_thread.run() {
                         error!("Error occurred during ChainController loop: {:?}", err);
                     }
                 })
-                .unwrap();
-
-            self.start_validation_result_thread(exit_flag.clone(), validation_result_receiver);
-            self.start_commit_queue_thread(exit_flag, commit_queue_receiver);
+                .expect("Unable to start ChainThread");
         }
-    }
-
-    fn start_validation_result_thread(
-        &self,
-        result_thread_exit: Arc<AtomicBool>,
-        validation_result_receiver: Receiver<BlockValidationResult>,
-    ) {
-        // Setup the ValidationResult thread
-        let result_thread_builder =
-            thread::Builder::new().name("ChainThread:ValidationResultReceiver".into());
-        let result_thread_controller = self.light_clone();
-        result_thread_builder
-            .spawn(move || loop {
-                let block_validation_result = match validation_result_receiver
-                    .recv_timeout(Duration::from_millis(RECV_TIMEOUT_MILLIS))
-                {
-                    Err(mpsc::RecvTimeoutError::Timeout) => {
-                        if result_thread_exit.load(Ordering::Relaxed) {
-                            break;
-                        } else {
-                            continue;
-                        }
-                    }
-                    Err(_) => {
-                        error!("Result queue shutdown unexpectedly");
-                        break;
-                    }
-                    Ok(res) => res,
-                };
-
-                if !result_thread_exit.load(Ordering::Relaxed) {
-                    result_thread_controller
-                        .set_block_validation_result(block_validation_result.clone());
-                    if let Some(block) = result_thread_controller
-                        .get_block(&block_validation_result.block_id) {
-                            result_thread_controller.on_block_validated(&block, &block_validation_result);
-                        } else {
-                            error!("During validation result thread loop, received a block validation result for a block that is not in the BlockManager");
-                        }
-
-                } else {
-                    break;
-                }
-            }).unwrap();
-    }
-
-    fn start_commit_queue_thread(
-        &self,
-        commit_thread_exit: Arc<AtomicBool>,
-        commit_queue_receiver: Receiver<BlockPair>,
-    ) {
-        // Setup the Commit thread:
-        let commit_thread_builder =
-            thread::Builder::new().name("ChainThread:CommitReceiver".into());
-        let mut commit_thread_controller = self.light_clone();
-        commit_thread_builder
-            .spawn(move || loop {
-                let block = match commit_queue_receiver
-                    .recv_timeout(Duration::from_millis(RECV_TIMEOUT_MILLIS))
-                {
-                    Err(mpsc::RecvTimeoutError::Timeout) => {
-                        if commit_thread_exit.load(Ordering::Relaxed) {
-                            break;
-                        } else {
-                            continue;
-                        }
-                    }
-                    Err(_) => {
-                        error!("Commit queue shutdown unexpectedly");
-                        break;
-                    }
-                    Ok(res) => res,
-                };
-
-                if !commit_thread_exit.load(Ordering::Relaxed) {
-                    if let Err(err) = commit_thread_controller.handle_block_commit(&block) {
-                        error!(
-                            "An error occurred while committing block {}: {:?}",
-                            block.block(),
-                            err
-                        );
-                    }
-                } else {
-                    break;
-                }
-            })
-            .unwrap();
     }
 
     pub fn stop(&mut self) {
@@ -1059,6 +554,389 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
             handle.stop();
         }
     }
+}
+
+/// This is used by a non-genesis journal when it has received the
+/// genesis block from the genesis validator
+fn set_genesis<TEP: ExecutionPlatform + Clone + 'static>(
+    state: &mut ChainControllerState,
+    chain_head_lock: &ChainHeadLock,
+    block: &BlockPair,
+    block_validator: &BlockValidator<TEP>,
+    block_validation_results: &BlockValidationResultStore,
+) -> Result<(), ChainControllerError> {
+    if block.header().previous_block_id() == NULL_BLOCK_IDENTIFIER {
+        let chain_id = state.chain_id_manager.get_block_chain_id()?;
+        if chain_id
+            .as_ref()
+            .map(|block_id| block_id != block.block().header_signature())
+            .unwrap_or(false)
+        {
+            warn!(
+                "Block id does not match block chain id {}. Ignoring initial chain head: {}",
+                chain_id.unwrap(),
+                block.block().header_signature()
+            );
+        } else {
+            block_validator.validate_block(&block)?;
+
+            if chain_id.is_none() {
+                state
+                    .chain_id_manager
+                    .save_block_chain_id(block.block().header_signature())?;
+            }
+
+            state
+                .block_manager
+                .persist(block.block().header_signature(), COMMIT_STORE)?;
+
+            // Create Ref-C: External reference for the chain head will be held until it is
+            // superceded by a new chain head.
+            state.chain_head = Some(
+                state
+                    .block_manager
+                    .ref_block(block.block().header_signature())?,
+            );
+
+            match block_validation_results.get(block.block().header_signature()) {
+                Some(validation_results) => {
+                    let receipts: Vec<TransactionReceipt> = validation_results
+                        .execution_results
+                        .iter()
+                        .map(TransactionReceipt::from)
+                        .collect();
+                    for observer in &mut state.observers {
+                        observer.chain_update(&block, receipts.as_slice());
+                    }
+                }
+                None => {
+                    error!(
+                        "While committing {}, found block missing execution results",
+                        block.block(),
+                    );
+                }
+            }
+
+            let mut guard = chain_head_lock.acquire();
+            guard.notify_on_chain_updated(block.clone(), vec![], vec![]);
+        }
+    }
+
+    Ok(())
+}
+
+fn on_block_received<TEP: ExecutionPlatform + Clone + 'static>(
+    block_id: &str,
+    state: &mut ChainControllerState,
+    consensus_notifier: &Arc<dyn ConsensusNotifier>,
+    chain_head_lock: &ChainHeadLock,
+    block_validator: &BlockValidator<TEP>,
+    block_validation_results: &BlockValidationResultStore,
+) -> Result<(), ChainControllerError> {
+    if state.chain_head.is_none() {
+        if let Some(Some(block)) = state.block_manager.get(&[&block_id]).next() {
+            if let Err(err) = set_genesis(
+                state,
+                &chain_head_lock,
+                &block,
+                &block_validator,
+                &block_validation_results,
+            ) {
+                warn!(
+                    "Unable to set chain head; genesis block {} is not valid: {:?}",
+                    block.block().header_signature(),
+                    err
+                );
+            }
+        } else {
+            warn!("Received block not in block manager");
+        }
+        return Ok(());
+    }
+
+    let block = {
+        if let Some(Some(block)) = state.block_manager.get(&[&block_id]).next() {
+            // Create Ref-C: Hold this reference until consensus renders a {commit, ignore, or
+            // fail} opinion on the block.
+            match state.block_manager.ref_block(&block_id) {
+                Ok(block_ref) => {
+                    state
+                        .block_references
+                        .insert(block_ref.block_id().to_owned(), block_ref);
+                    consensus_notifier.notify_block_new(&block);
+                    Some(block)
+                }
+                Err(err) => {
+                    error!(
+                        "Unable to ref block {} received from completer; ignoring: {:?}",
+                        &block_id, err
+                    );
+                    None
+                }
+            }
+        } else {
+            warn!(
+                "Received block id for block not in block manager: {}",
+                block_id
+            );
+            None
+        }
+    };
+
+    if let Some(block) = block {
+        // Transfer Ref-B: Implicitly transfer ownership of the external reference placed on
+        // this block by the completer. The ForkCache is now responsible for unrefing the block
+        // when it expires. This happens when either 1) the block is replaced in the cache by
+        // another block which extends it, at which point this block will have an int. ref.
+        // count of at least 1, or 2) the fork becomes inactive the block is purged, at which
+        // point the block may be dropped if no other ext. ref's exist.
+        if let Some(previous_block_id) = state
+            .fork_cache
+            .insert(&block_id, Some(block.header().previous_block_id()))
+        {
+            // Drop Ref-B: This fork was extended and so this block has an int. ref. count of
+            // at least one, so we can drop the ext. ref. placed on the block to keep the fork
+            // around.
+            match state.block_manager.unref_block(&previous_block_id) {
+                Ok(true) => {
+                    panic!(
+                        "Block {:?} was unref'ed because it was the head of a fork that was
+                        just extended. The unref caused the block to drop, but it should have
+                        had an internal reference count of at least 1.",
+                        previous_block_id,
+                    );
+                }
+                Ok(false) => (),
+                Err(err) => error!(
+                    "Failed to unref expired block {}: {:?}",
+                    previous_block_id, err
+                ),
+            }
+        }
+
+        for block_id in state.fork_cache.purge() {
+            // Drop Ref-B: The fork is no longer active, and we have to drop the ext. ref.
+            // placed on the block to keep the fork around.
+            if let Err(err) = state.block_manager.unref_block(&block_id) {
+                error!("Failed to unref expired block {}: {:?}", block_id, err);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_block_commit(
+    block: &BlockPair,
+    state: &mut ChainControllerState,
+    chain_head_lock: &ChainHeadLock,
+    consensus_notifier: &Arc<dyn ConsensusNotifier>,
+    state_pruning_block_depth: u32,
+    block_validation_results: &BlockValidationResultStore,
+) -> Result<(), ChainControllerError> {
+    {
+        loop {
+            let chain_head = state
+                .chain_reader
+                .chain_head()
+                .map_err(|err| {
+                    error!("Error reading chain head: {:?}", err);
+                    err
+                })?
+                .expect(
+                    "Attempting to handle block commit before a genesis block has been
+                    committed",
+                );
+            let result = state.build_fork(block, &chain_head).map_err(|err| {
+                error!(
+                    "Error occured while building fork resolution result: {:?}",
+                    err,
+                );
+                err
+            })?;
+
+            let mut chain_head_guard = chain_head_lock.acquire();
+            let chain_head_updated = state
+                .check_chain_head_updated(&chain_head, &block)
+                .map_err(|err| {
+                    error!(
+                        "Error occured while checking if chain head updated: {:?}",
+                        err,
+                    );
+                    err
+                })?;
+            if chain_head_updated {
+                continue;
+            }
+
+            // Move Ref-C: Consensus has decided this block should become the new chain
+            // head, so the ChainController will maintain ownership of this ext. ref until a
+            // new chain head replaces it.
+            state.chain_head = Some(
+                state
+                    .block_references
+                    .remove(block.block().header_signature())
+                    .ok_or_else(|| {
+                        ChainControllerError::ConsensusError(
+                            "Consensus has already decided on this block".into(),
+                        )
+                    })?,
+            );
+
+            let new_roots = result
+                .new_chain
+                .iter()
+                .map(|block| block.header().state_root_hash())
+                .collect::<Vec<_>>();
+            let current_roots = result
+                .current_chain
+                .iter()
+                .map(|block| (block.header().block_num(), block.header().state_root_hash()))
+                .collect::<Vec<_>>();
+            state
+                .state_pruning_manager
+                .update_queue(new_roots.as_slice(), current_roots.as_slice());
+
+            state
+                .block_manager
+                .persist(block.block().header_signature(), COMMIT_STORE)
+                .map_err(|err| {
+                    error!("Error persisting new chain head: {:?}", err);
+                    err
+                })?;
+
+            info!("Chain head updated to {}", block.block());
+
+            consensus_notifier.notify_block_commit(block.block().header_signature());
+
+            counter!(
+                "chain.ChainController.committed_transactions_count",
+                result.transaction_count as u64
+            );
+            gauge!(
+                "chain.ChainController.block_num",
+                block.header().block_num() as i64
+            );
+
+            chain_head_guard.notify_on_chain_updated(
+                block.clone(),
+                result.committed_batches,
+                result.uncommitted_batches,
+            );
+
+            block.block().batches().iter().for_each(|batch| {
+                if batch.trace() {
+                    debug!(
+                        "TRACE: {}: ChainController.on_block_validated",
+                        batch.header_signature()
+                    )
+                }
+            });
+
+            for blk in result.new_chain.iter().rev() {
+                match block_validation_results.get(blk.block().header_signature()) {
+                    Some(validation_results) => {
+                        let receipts: Vec<TransactionReceipt> = validation_results
+                            .execution_results
+                            .iter()
+                            .map(TransactionReceipt::from)
+                            .collect();
+                        for observer in &mut state.observers {
+                            observer.chain_update(&block, receipts.as_slice());
+                        }
+                    }
+                    None => {
+                        error!(
+                            "While committing {}, found block {} missing execution results",
+                            block.block(),
+                            blk.block(),
+                        );
+                    }
+                }
+            }
+
+            let total_committed_txns = match state.chain_reader.count_committed_transactions() {
+                Ok(count) => count,
+                Err(err) => {
+                    error!(
+                        "Unable to read total committed transactions count: {:?}",
+                        err
+                    );
+                    0
+                }
+            };
+
+            gauge!(
+                "chain.ChainController.committed_transactions_gauge",
+                total_committed_txns as i64
+            );
+
+            let chain_head_block_num = block.header().block_num();
+            if chain_head_block_num + 1 > u64::from(state_pruning_block_depth) {
+                let prune_at = chain_head_block_num - (u64::from(state_pruning_block_depth));
+                match state.chain_reader.get_block_by_block_num(prune_at) {
+                    Ok(Some(block)) => state
+                        .state_pruning_manager
+                        .add_to_queue(block.header().block_num(), block.header().state_root_hash()),
+                    Ok(None) => warn!("No block at block height {}; ignoring...", prune_at),
+                    Err(err) => error!("Unable to fetch block at height {}: {:?}", prune_at, err),
+                }
+
+                // Execute pruning:
+                state.state_pruning_manager.execute(prune_at)
+            }
+
+            // Updated the block, so we're done
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+fn on_block_validated<TEP: ExecutionPlatform + Clone + 'static>(
+    state: &mut ChainControllerState,
+    block: &BlockPair,
+    result: &BlockValidationResult,
+    consensus_notifier: &Arc<dyn ConsensusNotifier>,
+    validation_sender: &Sender<ChainControllerRequest>,
+    block_validator: &BlockValidator<TEP>,
+) {
+    counter!("chain.ChainController.blocks_considered_count", 1);
+
+    match result.status {
+        BlockStatus::Valid => {
+            // Keep Ref-C: The block has been validated so ownership of the ext. ref. is
+            // maintained. The consensus engine is responsible for rendering an opinion of
+            // either commit, fail, or ignore, at which time the ext. ref. will be accounted
+            // for (moved into chain head in case of commit, dropped otherwise)
+            consensus_notifier.notify_block_valid(block.block().header_signature());
+        }
+        BlockStatus::Invalid => {
+            consensus_notifier.notify_block_invalid(block.block().header_signature());
+
+            // Drop Ref-C: The block has been found to be invalid, and we are no longer
+            // interested in it. The invalid result will be cached for a period.
+            if state
+                .block_references
+                .remove(block.block().header_signature())
+                .is_none()
+            {
+                error!(
+                    "Reference not found for invalid block {}",
+                    block.block().header_signature()
+                );
+            }
+        }
+        _ => error!(
+            "on_block_validated() called for block {}, but result was {:?}",
+            block.block().header_signature(),
+            result.status,
+        ),
+    }
+
+    // notify block validation results received
+    block_validator.process_pending(block, validation_sender);
 }
 
 impl<'a> From<&'a TxnExecutionResult> for TransactionReceipt {
@@ -1074,10 +952,31 @@ impl<'a> From<&'a TxnExecutionResult> for TransactionReceipt {
     }
 }
 
+/// Messages handling by the chain controller's thread
+pub enum ChainControllerRequest {
+    /// queue a block to be validated
+    QueueBlock(String),
+    /// handle committing a block
+    CommitBlock(BlockPair),
+    /// handle a block validation result
+    BlockValidation(BlockValidationResult),
+    /// submit block directly to the block validator for validation
+    ValidateBlock {
+        blocks: Vec<BlockPair>,
+        response_sender: Sender<ChainControllerRequest>,
+    },
+}
+
 struct ChainThread<TEP: ExecutionPlatform + Clone> {
-    chain_controller: ChainController<TEP>,
-    block_queue: Receiver<String>,
+    request_receiver: Receiver<ChainControllerRequest>,
     exit: Arc<AtomicBool>,
+    state: Arc<RwLock<ChainControllerState>>,
+    chain_head_lock: ChainHeadLock,
+    consensus_notifier: Arc<dyn ConsensusNotifier>,
+    state_pruning_block_depth: u32,
+    block_validation_results: BlockValidationResultStore,
+    block_validator: BlockValidator<TEP>,
+    validation_sender: Sender<ChainControllerRequest>,
 }
 
 trait StopHandle: Clone {
@@ -1085,22 +984,35 @@ trait StopHandle: Clone {
 }
 
 impl<TEP: ExecutionPlatform + Clone + 'static> ChainThread<TEP> {
+    #![allow(clippy::too_many_arguments)]
     fn new(
-        chain_controller: ChainController<TEP>,
-        block_queue: Receiver<String>,
+        request_receiver: Receiver<ChainControllerRequest>,
         exit_flag: Arc<AtomicBool>,
+        state: Arc<RwLock<ChainControllerState>>,
+        chain_head_lock: ChainHeadLock,
+        consensus_notifier: Arc<dyn ConsensusNotifier>,
+        state_pruning_block_depth: u32,
+        block_validation_results: BlockValidationResultStore,
+        block_validator: BlockValidator<TEP>,
+        validation_sender: Sender<ChainControllerRequest>,
     ) -> Self {
         ChainThread {
-            chain_controller,
-            block_queue,
+            request_receiver,
             exit: exit_flag,
+            state,
+            chain_head_lock,
+            consensus_notifier,
+            state_pruning_block_depth,
+            block_validation_results,
+            block_validator,
+            validation_sender,
         }
     }
 
     fn run(&mut self) -> Result<(), ChainControllerError> {
         loop {
-            let block_id = match self
-                .block_queue
+            let request = match self
+                .request_receiver
                 .recv_timeout(Duration::from_millis(RECV_TIMEOUT_MILLIS))
             {
                 Err(mpsc::RecvTimeoutError::Timeout) => {
@@ -1113,12 +1025,89 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainThread<TEP> {
                 Err(_) => break Err(ChainControllerError::BrokenQueue),
                 Ok(block_id) => block_id,
             };
-            self.chain_controller.on_block_received(&block_id)?;
 
-            if self.exit.load(Ordering::Relaxed) {
-                break Ok(());
+            match request {
+                ChainControllerRequest::QueueBlock(block_id) => {
+                    let mut state = self
+                        .state
+                        .write()
+                        .expect("No lock holder should have poisoned the lock");
+
+                    if let Err(err) = on_block_received(
+                        &block_id,
+                        &mut state,
+                        &self.consensus_notifier,
+                        &self.chain_head_lock,
+                        &self.block_validator,
+                        &self.block_validation_results,
+                    ) {
+                        error!("Error was return from on block received: {:?}", err);
+                    }
+
+                    if self.exit.load(Ordering::Relaxed) {
+                        break Ok(());
+                    }
+                }
+                ChainControllerRequest::CommitBlock(block) => {
+                    let mut state = self
+                        .state
+                        .write()
+                        .expect("No lock holder should have poisoned the lock");
+
+                    if let Err(err) = handle_block_commit(
+                        &block,
+                        &mut state,
+                        &self.chain_head_lock,
+                        &self.consensus_notifier,
+                        self.state_pruning_block_depth,
+                        &self.block_validation_results,
+                    ) {
+                        error!("Error was return from handle block commit: {:?}", err);
+                    }
+                }
+                ChainControllerRequest::ValidateBlock {
+                    blocks,
+                    response_sender,
+                } => {
+                    self.block_validator
+                        .submit_blocks_for_verification(blocks, response_sender);
+                }
+                ChainControllerRequest::BlockValidation(block_validation_result) => {
+                    self.block_validation_results
+                        .insert(block_validation_result.clone());
+                    let mut state = self
+                        .state
+                        .write()
+                        .expect("No lock holder should have poisoned the lock");
+                    if let Some(block) = state
+                        .block_manager
+                        .get(&[&block_validation_result.block_id])
+                        .next()
+                        .unwrap_or(None)
+                    {
+                        on_block_validated(
+                            &mut state,
+                            &block,
+                            &block_validation_result,
+                            &self.consensus_notifier,
+                            &self.validation_sender,
+                            &self.block_validator,
+                        )
+                    } else {
+                        error!(
+                            "Received a block validation result for a block that is not in the \
+                            BlockManager"
+                        );
+                    }
+                }
             }
         }
+    }
+}
+
+impl From<BlockValidationResult> for ChainControllerRequest {
+    fn from(result: BlockValidationResult) -> Self {
+        ChainControllerRequest::BlockValidation(result)
     }
 }
 

--- a/libsawtooth/src/journal/chain.rs
+++ b/libsawtooth/src/journal/chain.rs
@@ -1127,6 +1127,3 @@ impl StopHandle for ChainThreadStopHandle {
         self.exit.store(true, Ordering::Relaxed)
     }
 }
-
-#[cfg(tests)]
-mod tests {}

--- a/libsawtooth/src/journal/chain.rs
+++ b/libsawtooth/src/journal/chain.rs
@@ -244,7 +244,6 @@ impl ChainControllerState {
     }
 }
 
-#[derive(Clone)]
 pub struct ChainController<TEP: ExecutionPlatform + Clone> {
     state: Arc<RwLock<ChainControllerState>>,
     stop_handle: Arc<Mutex<Option<ChainThreadStopHandle>>>,

--- a/libsawtooth/src/journal/chain.rs
+++ b/libsawtooth/src/journal/chain.rs
@@ -37,7 +37,7 @@ use std::time::Duration;
 use transact::protocol::batch::Batch;
 
 use crate::{
-    consensus::{notifier::ConsensusNotifier, registry::ConsensusRegistry},
+    consensus::notifier::ConsensusNotifier,
     execution::execution_platform::ExecutionPlatform,
     journal::chain_head_lock::ChainHeadLock,
     journal::{
@@ -53,7 +53,7 @@ use crate::{
     protocol::block::BlockPair,
     protos::transaction_receipt::TransactionReceipt,
     scheduler::TxnExecutionResult,
-    state::{state_pruning_manager::StatePruningManager, state_view_factory::StateViewFactory},
+    state::state_pruning_manager::StatePruningManager,
 };
 
 pub const COMMIT_STORE: &str = "commit_store";
@@ -249,8 +249,6 @@ pub struct ChainController<TEP: ExecutionPlatform + Clone> {
     stop_handle: Arc<Mutex<Option<ChainThreadStopHandle>>>,
 
     consensus_notifier: Arc<dyn ConsensusNotifier>,
-    consensus_registry: Arc<dyn ConsensusRegistry>,
-    state_view_factory: StateViewFactory,
     block_validator: Option<BlockValidator<TEP>>,
     block_validation_results: BlockValidationResultStore,
 
@@ -270,8 +268,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
         chain_head_lock: ChainHeadLock,
         block_validation_results: BlockValidationResultStore,
         consensus_notifier: Box<dyn ConsensusNotifier>,
-        consensus_registry: Box<dyn ConsensusRegistry>,
-        state_view_factory: StateViewFactory,
         data_dir: String,
         state_pruning_block_depth: u32,
         observers: Vec<Box<dyn ChainObserver>>,
@@ -296,8 +292,6 @@ impl<TEP: ExecutionPlatform + Clone + 'static> ChainController<TEP> {
             state_pruning_block_depth,
             chain_head_lock,
             consensus_notifier: Arc::from(consensus_notifier),
-            consensus_registry: Arc::from(consensus_registry),
-            state_view_factory,
         };
 
         chain_controller.initialize_chain_head();


### PR DESCRIPTION
Previously, the chain controller would be "light_cloned" into several
threads. This commit removes ChainController.light_clone method and instead
moves more functionality into ChainThread.

The 3 required channels used to call methods on chain controller from
other components have been reduced down to one that handle
ChainControllerRequests messages in a loop. Combining these threads
into one removes the need to clone the chain controller.

The BlockValidator has also been updated to return a ChainControllerRequest
on block validation instead of the BlockValidationResult directly.

This change is in support of replacing the Sawtooth transaction executor with
Transact's Executor in the BlockValidator.
