### PR TITLE
Rewrite validation rule enforcement

### DIFF
--- a/libsawtooth/src/journal/block_manager.rs
+++ b/libsawtooth/src/journal/block_manager.rs
@@ -37,6 +37,23 @@ pub enum BlockManagerError {
     BlockStoreError,
 }
 
+impl std::error::Error for BlockManagerError {}
+
+impl std::fmt::Display for BlockManagerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::MissingPredecessor(msg) => write!(f, "missing predecessor block: {}", msg),
+            Self::MissingPredecessorInBranch(msg) => {
+                write!(f, "missing predecessor block in branch: {}", msg)
+            }
+            Self::MissingInput => f.write_str("missing input"),
+            Self::UnknownBlock => f.write_str("unknown block"),
+            Self::UnknownBlockStore => f.write_str("unknown block store"),
+            Self::BlockStoreError => f.write_str("block store error"),
+        }
+    }
+}
+
 impl From<BlockStoreError> for BlockManagerError {
     fn from(_other: BlockStoreError) -> Self {
         BlockManagerError::BlockStoreError

--- a/libsawtooth/src/journal/validation_rule_enforcer.rs
+++ b/libsawtooth/src/journal/validation_rule_enforcer.rs
@@ -15,226 +15,370 @@
  * ------------------------------------------------------------------------------
  */
 
-use transact::protocol::{batch::Batch, transaction::TransactionHeader};
+/// Enforces block validation rules
+use std::convert::TryFrom;
+use std::str::FromStr;
+
+use transact::protocol::{batch::Batch, transaction::Transaction};
 
 use crate::state::settings_view::SettingsView;
 
-/// Retrieve the validation rules stored in state and check that the
-/// given batches do not violate any of those rules. These rules include:
-///
-/// ```ignore
-///     NofX: Only N of transaction type X may be included in a block.
-///     XatY: A transaction of type X must be in the list at position Y.
-///     local: A transaction must be signed by the given public key
-///```
-///
-/// If any setting stored in state does not match the required format for
-/// that rule, the rule will be ignored.
-///
-/// Args:
-///     settings_view (:obj:SettingsView): the settings view to find the
-///         current rule values
-///     expected_signer (str): the public key used to use for local signing
-///     batches (:list:Batch): the list of batches to validate
-pub fn enforce_validation_rules(
-    settings_view: &SettingsView,
-    expected_signer: &[u8],
-    batches: &[Batch],
-) -> bool {
-    let rules = settings_view
-        .get_setting_str("sawtooth.validator.block_validation_rules", None)
-        .expect("Unable to get setting");
-    enforce_rules(rules, expected_signer, batches)
+const BLOCK_VALIDATION_RULES: &str = "sawtooth.validator.block_validation_rules";
+
+/// Reads the block validation rules in state and enforces that blocks conform to those rules
+pub struct ValidationRuleEnforcer {
+    rules: Vec<Rule>,
+    local_signer_key: Vec<u8>,
+    txn_info: Vec<TxnInfo>,
 }
 
-fn enforce_rules(rules: Option<String>, expected_signer: &[u8], batches: &[Batch]) -> bool {
-    if rules.is_none() {
-        return true;
+impl ValidationRuleEnforcer {
+    /// Creates a new validation rule enforcer by reading the rules from state
+    ///
+    /// # Arguments
+    ///
+    /// * `settings_view` - The view of state used to read the block validation rules setting
+    /// * `local_signer_key` - The public key of the node that produced the block being validated;
+    ///   it is expected to be the signer of local transactions
+    pub fn new(
+        settings_view: &SettingsView,
+        local_signer_key: Vec<u8>,
+    ) -> Result<Self, ValidationRuleEnforcerError> {
+        let rules = settings_view
+            .get_setting_str(BLOCK_VALIDATION_RULES, None)
+            .map_err(|err| ValidationRuleEnforcerError::Internal(err.to_string()))?
+            .map(|rules_str| parse_rules(&rules_str))
+            .transpose()?
+            .unwrap_or_default();
+
+        Ok(Self {
+            rules,
+            local_signer_key,
+            txn_info: vec![],
+        })
     }
 
-    let txn_headers = match batches
-        .iter()
-        .flat_map(|batch| batch.transactions())
-        .cloned()
-        .map(|txn| txn.into_pair().map(|txn_pair| txn_pair.take().1))
-        .collect::<Result<Vec<_>, _>>()
-    {
-        Ok(txn_headers) => txn_headers,
-        Err(err) => {
-            debug!("Unable to deserialize transaction header: {}", err);
-            return false;
+    /// Adds the given batches to a running-list and returns a boolean to indicate if all batches
+    /// received so-far follow the rules.
+    ///
+    /// If not enough batches/transactions have been added to verify rules based on the position of
+    /// batches/transactions, those rules are ignored.
+    pub fn add_batches<'a, I: IntoIterator<Item = &'a Batch>>(
+        &mut self,
+        batches: I,
+    ) -> Result<bool, ValidationRuleEnforcerError> {
+        if self.rules.is_empty() {
+            return Ok(true);
         }
-    };
 
-    let mut valid = true;
-    for rule_str in rules.unwrap().split(';') {
-        if let Some((rule_type, arguments)) = parse_rule(rule_str) {
-            if rule_type == "NofX" {
-                valid = do_nofx(&txn_headers, &arguments);
-            } else if rule_type == "XatY" {
-                valid = do_xaty(&txn_headers, &arguments);
-            } else if rule_type == "local" {
-                valid = do_local(&txn_headers, expected_signer, &arguments);
-            }
+        // Store the info from all transactions
+        batches
+            .into_iter()
+            .flat_map(|batch| batch.transactions())
+            .cloned()
+            .try_for_each(|txn| {
+                self.txn_info.push(TxnInfo::try_from(txn)?);
+                Ok(())
+            })?;
 
-            if !valid {
-                return false;
+        Ok(self.validate(false))
+    }
+
+    /// Returns whether or not the added batches follow the rules. If `final_validation` is true,
+    /// all position-based rules will be enforced; if there is no batch/transaction at the position
+    /// required by a rule, validation will fail.
+    pub fn validate(&self, final_validation: bool) -> bool {
+        self.rules
+            .iter()
+            .all(|rule| rule.validate(&self.txn_info, &self.local_signer_key, final_validation))
+    }
+}
+
+/// Parses the whole rules string, which is in the form "<rule1>;<rule2>;*"
+fn parse_rules(rules_str: &str) -> Result<Vec<Rule>, ValidationRuleEnforcerError> {
+    if rules_str.is_empty() {
+        Ok(vec![])
+    } else {
+        rules_str.split(';').map(Rule::from_str).collect()
+    }
+}
+
+/// Native representation of the validation rules
+#[derive(Debug)]
+enum Rule {
+    /// Only N (`limit`) of transaction type X (`family_name`) may be included in a block
+    NofX { family_name: String, limit: usize },
+    /// A transaction of type X (`family_name`) must be in the list of transactions at Y
+    /// (`position`)
+    XatY {
+        family_name: String,
+        position: usize,
+    },
+    /// The transactions at the given `indices` must be signed by the same key that signed the block
+    Local { indices: Vec<usize> },
+}
+
+impl Rule {
+    /// Verifies the rule is not violated by the given list of transactions
+    ///
+    /// # Arguments
+    ///
+    /// * `txn_info` - The list of transactions (reduced to only relevant info) to validate
+    /// * `local_signer_key` - The key used for validating the `Local` rule
+    /// * `final_validation` - If `true`, the `XatY` and `Local` rules will fail when there is no
+    ///   transactions at the required position
+    pub fn validate(
+        &self,
+        txn_info: &[TxnInfo],
+        local_signer_key: &[u8],
+        final_validation: bool,
+    ) -> bool {
+        match self {
+            Self::NofX { family_name, limit } => {
+                let count = txn_info
+                    .iter()
+                    .filter(|info| &info.family_name == family_name)
+                    .count();
+                if count > *limit {
+                    debug!(
+                        "Found {} transactions of type {}; only {} are allowed",
+                        count, family_name, limit
+                    );
+                    false
+                } else {
+                    true
+                }
             }
-        } else {
-            warn!(
-                "Validation rule Ignored, not in the correct format: {}",
+            Self::XatY {
+                family_name,
+                position,
+            } => {
+                let txn_family_name = match txn_info.get(*position) {
+                    Some(info) => &info.family_name,
+                    None if final_validation => {
+                        debug!(
+                            "Transaction at position {} is required by XatY rule",
+                            position
+                        );
+                        return false;
+                    }
+                    None => return true, // Haven't gotten txn at position Y yet
+                };
+                if txn_family_name != family_name {
+                    debug!(
+                        "Transaction at position {} is not of the correct type; expected {}, \
+                         found {}",
+                        position, family_name, txn_info[*position].family_name
+                    );
+                    false
+                } else {
+                    true
+                }
+            }
+            Self::Local { indices } => {
+                for index in indices {
+                    let signer_key = match txn_info.get(*index) {
+                        Some(info) => info.signer_public_key.as_slice(),
+                        None if final_validation => {
+                            debug!("Transaction at index {} is required by local rule", index);
+                            return false;
+                        }
+                        None => return true, // Haven't gotten txn at this index yet
+                    };
+                    if signer_key != local_signer_key {
+                        debug!(
+                            "Transaction at position {} is not signed by the local key {}",
+                            index,
+                            hex::encode(local_signer_key)
+                        );
+                        return false;
+                    }
+                }
+                true
+            }
+        }
+    }
+}
+
+impl FromStr for Rule {
+    type Err = ValidationRuleEnforcerError;
+
+    /// Parses a rule string, which is in the form "<rule_type>:<rule_arg1>,<rule_arg2>,*"
+    fn from_str(rule_str: &str) -> Result<Self, Self::Err> {
+        let mut rule_parts = rule_str.split(':');
+
+        let rule_type = rule_parts.next().expect("split cannot return empty iter");
+
+        let rule_args = rule_parts
+            .next()
+            .ok_or_else(|| {
+                ValidationRuleEnforcerError::InvalidRule(format!(
+                    "empty arguments string for rule: {}",
+                    rule_str
+                ))
+            })?
+            .split(',')
+            .map(|arg| {
+                if arg.is_empty() {
+                    Err(ValidationRuleEnforcerError::InvalidRule(format!(
+                        "empty argument for rule: {}",
+                        rule_str
+                    )))
+                } else {
+                    Ok(arg.to_string())
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if rule_args.is_empty() {
+            return Err(ValidationRuleEnforcerError::InvalidRule(format!(
+                "no arguments provided for rule: {}",
                 rule_str
-            );
+            )));
         }
-    }
 
-    valid
-}
+        match rule_type {
+            // The "NofX" rule has two arguments: a limit (the integer that indicates the max
+            // number of transactions) and a family name (the name of the transaction family that
+            // is being limited).
+            //
+            // Example: "NofX:2,intkey" means only 2 intkey transactions are allowed per block.
+            "NofX" => {
+                let limit = rule_args
+                    .get(0)
+                    .ok_or_else(|| {
+                        ValidationRuleEnforcerError::InvalidRule(
+                            "found NofX rule with no arguments".into(),
+                        )
+                    })?
+                    .trim()
+                    .parse()
+                    .map_err(|_| {
+                        ValidationRuleEnforcerError::InvalidRule(
+                            "found NofX rule with non-integer limit".into(),
+                        )
+                    })?;
 
-/// Only N of transaction type X may be included in a block. The first
-/// argument must be interpretable as an integer. The second argument is
-/// interpreted as the name of a transaction family. For example, the
-/// string "NofX:2,intkey" means only allow 2 intkey transactions per
-/// block.
-fn do_nofx(txn_headers: &[TransactionHeader], arguments: &[&str]) -> bool {
-    let (limit, family) = if arguments.len() == 2 {
-        let limit: usize = match arguments[0].trim().parse() {
-            Ok(i) => i,
-            Err(_) => {
-                warn!(
-                    "Ignore, NofX requires limit to be a number, not {}",
-                    arguments[0]
-                );
-                return true;
+                let family_name = rule_args
+                    .get(1)
+                    .ok_or_else(|| {
+                        ValidationRuleEnforcerError::InvalidRule(
+                            "found NofX rule with no family name argument".into(),
+                        )
+                    })?
+                    .trim()
+                    .to_string();
+
+                Ok(Rule::NofX { family_name, limit })
             }
-        };
-        let family = arguments[1].trim();
-        (limit, family)
-    } else {
-        warn!(
-            "Ignore, NofX requires arguments in the format 'limit,family' not {:?}",
-            arguments
-        );
-        return true;
-    };
+            // The "XatY" rule has two arguments: a family name (the name of the transaction family
+            // that must be present) and a position (the position in the list of transactions where
+            // a transaction of the right type must be present). The first transaction in a block
+            // has index 0. If the position is larger than the number of transactions in a block,
+            // then there would not be a transaction of type X at Y; this will fail when performing
+            // "final validation".
+            //
+            // Example: "XatY:intkey,0" means the first transaction in a block must be an intkey
+            // transaction.
+            "XatY" => {
+                let family_name = rule_args
+                    .get(0)
+                    .ok_or_else(|| {
+                        ValidationRuleEnforcerError::InvalidRule(
+                            "found XatY rule with no arguments".into(),
+                        )
+                    })?
+                    .trim()
+                    .to_string();
 
-    let mut count = 0usize;
+                let position = rule_args
+                    .get(1)
+                    .ok_or_else(|| {
+                        ValidationRuleEnforcerError::InvalidRule(
+                            "found XatY rule with no position argument".into(),
+                        )
+                    })?
+                    .trim()
+                    .parse()
+                    .map_err(|_| {
+                        ValidationRuleEnforcerError::InvalidRule(
+                            "found XatY rule with non-integer position".into(),
+                        )
+                    })?;
 
-    for header in txn_headers {
-        if header.family_name() == family {
-            count += 1;
-        }
-
-        if count > limit {
-            debug!("Too many transactions of type {}", family);
-            return false;
-        }
-    }
-
-    true
-}
-
-/// A transaction of type X must be in the block at position Y. The
-/// first argument is interpreted as the name of a transaction family.
-/// The second argument must be interpretable as an integer and defines
-/// the index of the transaction in the block that must be checked.
-/// Negative numbers can be used and count backwards from the last
-/// transaction in the block. The first transaction in the block has
-/// index 0. The last transaction in the block has index -1. If abs(Y)
-/// is larger than the number of transactions per block, then there
-/// would not be a transaction of type X at Y and the block would be
-/// invalid. For example, the string "XatY:intkey,0" means the first
-/// transaction in the block must be an intkey transaction.
-fn do_xaty(txn_headers: &[TransactionHeader], arguments: &[&str]) -> bool {
-    let (family, position) = if arguments.len() == 2 {
-        let family = arguments[0].trim();
-        let position: usize = match arguments[1].trim().parse() {
-            Ok(i) => i,
-            Err(_) => {
-                warn!(
-                    "Ignore, XatY requires position to be a number, not {}",
-                    arguments[1]
-                );
-                return true;
+                Ok(Rule::XatY {
+                    family_name,
+                    position,
+                })
             }
-        };
-        (family, position)
-    } else {
-        warn!(
-            "Ignore, XatY requires arguments in the format 'family,position' not {:?}",
-            arguments
-        );
-        return true;
-    };
-
-    if position >= txn_headers.len() {
-        debug!(
-            "Block does not have enough transactions to valid this rule XatY:{:?}",
-            arguments
-        );
-        return false;
-    }
-
-    if txn_headers[position].family_name() != family {
-        debug!(
-            "Transaction at position {} is not of type {}",
-            position, family
-        );
-        return false;
-    }
-
-    true
-}
-
-/// A transaction must be signed by the same key as the block. This
-/// rule takes a list of transaction indices in the block and enforces the
-/// rule on each. This rule is useful in combination with the other rules
-/// to ensure a client is not submitting transactions that should only be
-/// injected by the winning validator.
-fn do_local(txn_headers: &[TransactionHeader], expected_signer: &[u8], arguments: &[&str]) -> bool {
-    let indices: Result<Vec<usize>, _> = arguments.iter().map(|s| s.trim().parse()).collect();
-
-    if indices.is_err() || indices.as_ref().unwrap().is_empty() {
-        warn!(
-            "Ignore, local requires one or more comma separated integers \
-             that represent indices, not {:?}",
-            arguments
-        );
-        return true;
-    }
-
-    for index in indices.unwrap() {
-        if index >= txn_headers.len() {
-            debug!(
-                "Ignore, Block does not have enough transactions to validate this rule local: {}",
-                index
-            );
-            continue;
-        }
-
-        if txn_headers[index].signer_public_key() != expected_signer {
-            debug!(
-                "Transaction at  position {} was not signed by the expected signer.",
-                index
-            );
-            return false;
+            // The "Local" rules has a variable number of arguments; each one is an index at which
+            // there must be a transaction that is signed by the same key that signed the block.
+            // This rule is useful in combination with the other rules to ensure a client is not
+            // submitting transactions that should only be injected by the node that produced the
+            // block.
+            "local" => {
+                let indices = rule_args
+                    .iter()
+                    .map(|s| s.trim().parse())
+                    .collect::<Result<_, _>>()
+                    .map_err(|_| {
+                        ValidationRuleEnforcerError::InvalidRule(
+                            "found local rule with non-integer index".into(),
+                        )
+                    })?;
+                Ok(Rule::Local { indices })
+            }
+            rule_type => Err(ValidationRuleEnforcerError::InvalidRule(format!(
+                "unknown rule type: {}",
+                rule_type
+            ))),
         }
     }
-
-    true
 }
 
-/// Splits up a rule string in the form of "<rule_type>:<rule_arg>,*"
-fn parse_rule(rule: &str) -> Option<(&str, Vec<&str>)> {
-    let mut rule_parts: Vec<&str> = rule.split(':').collect();
-    if rule_parts.len() != 2 {
-        return None;
+/// Minimal set of information needed to verify the transactions in a block
+struct TxnInfo {
+    family_name: String,
+    signer_public_key: Vec<u8>,
+}
+
+impl TryFrom<Transaction> for TxnInfo {
+    type Error = ValidationRuleEnforcerError;
+
+    fn try_from(txn: Transaction) -> Result<Self, Self::Error> {
+        txn.into_pair()
+            .map(|txn_pair| Self {
+                family_name: txn_pair.header().family_name().into(),
+                signer_public_key: txn_pair.header().signer_public_key().into(),
+            })
+            .map_err(|err| {
+                ValidationRuleEnforcerError::InvalidBatches(format!(
+                    "failed to deserialize transaction header: {}",
+                    err
+                ))
+            })
     }
+}
 
-    let rule_args = rule_parts.pop().unwrap().split(',').collect::<Vec<_>>();
-    let rule_type = rule_parts.pop().unwrap();
+/// Errors that may occur when validating a block
+#[derive(Debug)]
+pub enum ValidationRuleEnforcerError {
+    Internal(String),
+    InvalidBatches(String),
+    InvalidRule(String),
+}
 
-    Some((rule_type.trim(), rule_args))
+impl std::error::Error for ValidationRuleEnforcerError {}
+
+impl std::fmt::Display for ValidationRuleEnforcerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Internal(msg) => f.write_str(msg),
+            Self::InvalidBatches(msg) => write!(f, "invalid batches were provided: {}", msg),
+            Self::InvalidRule(msg) => {
+                write!(f, "block validation rule configuration is invalid: {}", msg)
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -254,49 +398,75 @@ mod tests {
     #[test]
     fn test_no_setting() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(enforce_rules(None, PUB_KEY, &batches));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: vec![],
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+
+        assert!(enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(enforcer.validate(true));
     }
 
     /// Test that if NofX Rule is set, the validation rule is checked
     /// correctly. Test:
     ///     1. Valid Block, has one or less intkey transactions.
     ///     2. Invalid Block, to many intkey transactions.
-    ///     3. Valid Block, ignore rule because it is formatted incorrectly.
     #[test]
     fn test_n_of_x() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(enforce_rules(
-            Some("NofX:1,intkey".to_string()),
-            PUB_KEY,
-            &batches
-        ));
-        assert!(!enforce_rules(
-            Some("NofX:0,intkey".to_string()),
-            PUB_KEY,
-            &batches
-        ));
-        assert!(enforce_rules(Some("NofX:0".to_string()), PUB_KEY, &batches));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("NofX:1,intkey").expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(enforcer.validate(true));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("NofX:0,intkey").expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(!enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(!enforcer.validate(true));
     }
 
     /// Test that if XatY Rule is set, the validation rule is checked
     /// correctly. Test:
     ///     1. Valid Block, has intkey at the 0th position.
     ///     2. Invalid Block, does not have an blockinfo txn at the 0th postion
-    ///     3. Valid Block, ignore rule because it is formatted incorrectly.
     #[test]
     fn test_x_at_y() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(enforce_rules(
-            Some("XatY:intkey,0".to_string()),
-            PUB_KEY,
-            &batches
-        ));
-        assert!(!enforce_rules(
-            Some("XatY:blockinfo,0".to_string()),
-            PUB_KEY,
-            &batches
-        ));
-        assert!(enforce_rules(Some("XatY:0".to_string()), PUB_KEY, &batches));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("XatY:intkey,0").expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(enforcer.validate(true));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("XatY:blockinfo,0").expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(!enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(!enforcer.validate(true));
     }
 
     /// Test that if local Rule is set, the validation rule is checked
@@ -304,21 +474,29 @@ mod tests {
     ///     1. Valid Block, first transaction is signed by the expected signer.
     ///     2. Invalid Block, first transaction is not signed by the expected
     ///        signer.
-    ///     3. Valid Block, ignore rule because it is formatted incorrectly.
     #[test]
     fn test_local() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(enforce_rules(
-            Some("local:0".to_string()),
-            PUB_KEY,
-            &batches
-        ));
-        assert!(!enforce_rules(
-            Some("local:0".to_string()),
-            b"another_pub_key",
-            &batches
-        ));
-        assert!(enforce_rules(Some("local".to_string()), PUB_KEY, &batches));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("local:0").expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(enforcer.validate(true));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("local:0").expect("Failed to parse rules"),
+            local_signer_key: b"another_pub_key".to_vec(),
+            txn_info: vec![],
+        };
+        assert!(!enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(!enforcer.validate(true));
     }
 
     /// Test that if multiple rules are set, they are all checked correctly.
@@ -326,11 +504,17 @@ mod tests {
     #[test]
     fn test_all_at_once() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(enforce_rules(
-            Some("NofX:1,intkey;XatY:intkey,0;local:0".to_string()),
-            PUB_KEY,
-            &batches
-        ));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("NofX:1,intkey;XatY:intkey,0;local:0")
+                .expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(enforcer.validate(true));
     }
 
     /// Test that if multiple rules are set, they are all checked correctly.
@@ -338,11 +522,17 @@ mod tests {
     #[test]
     fn test_all_at_once_bad_number_of_intkey() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(!enforce_rules(
-            Some("NofX:0,intkey;XatY:intkey,0;local:0".to_string()),
-            PUB_KEY,
-            &batches
-        ));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("NofX:0,intkey;XatY:intkey,0;local:0")
+                .expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(!enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(!enforcer.validate(true));
     }
 
     /// Test that if multiple rules are set, they are all checked correctly.
@@ -351,11 +541,17 @@ mod tests {
     #[test]
     fn test_all_at_once_bad_family_at_index() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(!enforce_rules(
-            Some("NofX:1,intkey;XatY:blockinfo,0;local:0".to_string()),
-            PUB_KEY,
-            &batches
-        ));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("NofX:1,intkey;XatY:blockinfo,0;local:0")
+                .expect("Failed to parse rules"),
+            local_signer_key: PUB_KEY.into(),
+            txn_info: vec![],
+        };
+        assert!(!enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(!enforcer.validate(true));
     }
 
     /// Test that if multiple rules are set, they are all checked correctly.
@@ -364,11 +560,17 @@ mod tests {
     #[test]
     fn test_all_at_once_signer_key() {
         let batches = make_batches(&["intkey"], PUB_KEY);
-        assert!(!enforce_rules(
-            Some("NofX:1,intkey;XatY:intkey,0;local:0".to_string()),
-            b"not_same_pubkey",
-            &batches
-        ));
+
+        let mut enforcer = ValidationRuleEnforcer {
+            rules: parse_rules("NofX:1,intkey;XatY:intkey,0;local:0")
+                .expect("Failed to parse rules"),
+            local_signer_key: b"not_same_pubkey".to_vec(),
+            txn_info: vec![],
+        };
+        assert!(!enforcer
+            .add_batches(&batches)
+            .expect("Failed to add batches"));
+        assert!(!enforcer.validate(true));
     }
 
     fn make_batches(families: &[&str], pubkey: &[u8]) -> Vec<Batch> {

--- a/libsawtooth/src/state/settings_view.rs
+++ b/libsawtooth/src/state/settings_view.rs
@@ -17,6 +17,7 @@
 
 use std::cell::RefCell;
 use std::collections::HashMap;
+use std::error::Error;
 use std::iter::repeat;
 use std::num::ParseIntError;
 
@@ -36,6 +37,30 @@ pub enum SettingsViewError {
     EncodingError(ProtoConversionError),
 
     ParseIntError(ParseIntError),
+}
+
+impl Error for SettingsViewError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::StateDatabaseError(err) => Some(err),
+            Self::EncodingError(err) => Some(err),
+            Self::ParseIntError(err) => Some(err),
+        }
+    }
+}
+
+impl std::fmt::Display for SettingsViewError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::StateDatabaseError(err) => write!(
+                f,
+                "failed to access state database to get settings: {}",
+                err
+            ),
+            Self::EncodingError(err) => write!(f, "failed to deserialize settings data: {}", err),
+            Self::ParseIntError(err) => write!(f, "failed to parse setting as integer: {}", err),
+        }
+    }
 }
 
 impl From<StateDatabaseError> for SettingsViewError {


### PR DESCRIPTION
Replaces the
`sawtooth::journal::validation_rule_enforcer::enforce_validation_rules`
function with the `ValidationRuleEnforcer`. This struct allows the block
to be validated as it's constructed, which will be useful for the
publisher rewrite. Previously, all the batches had to be known to
validate the block correctly.

Signed-off-by: Logan Seeley <seeley@bitwise.io>