### PR TITLE
Add CborMerkleState for reading/writting cbor encoded state

### DIFF
--- a/libsawtooth/src/state/merkle.rs
+++ b/libsawtooth/src/state/merkle.rs
@@ -15,13 +15,15 @@
  * ------------------------------------------------------------------------------
  */
 
+use std::collections::HashMap;
 use std::io::Cursor;
 
-use cbor::decoder::GenericDecoder;
 use cbor::value::Bytes;
 use cbor::value::Value;
+use cbor::{decoder::GenericDecoder, encoder::GenericEncoder};
 
-use transact::state::merkle::MerkleRadixTree;
+use transact::state::merkle::{MerkleRadixTree, MerkleState};
+use transact::state::{Read, StateChange, StateReadError, StateWriteError, Write};
 
 use crate::state::error::StateDatabaseError;
 
@@ -35,6 +37,103 @@ pub fn decode_cbor_value(cbor_bytes: &[u8]) -> Result<Vec<u8>, StateDatabaseErro
     match decoded_value {
         Value::Bytes(Bytes::Bytes(bytes)) => Ok(bytes),
         _ => Err(StateDatabaseError::InvalidRecord),
+    }
+}
+
+pub fn encode_cbor_value(bytes: &[u8]) -> Result<Vec<u8>, StateDatabaseError> {
+    let mut encoder = GenericEncoder::new(Cursor::new(Vec::new()));
+    encoder
+        .value(&Value::Bytes(Bytes::Bytes(bytes.to_vec())))
+        .map_err(|_| StateDatabaseError::InvalidRecord)?;
+    Ok(encoder.into_inner().into_writer().into_inner())
+}
+
+#[derive(Clone)]
+pub struct CborMerkleState {
+    inner: MerkleState,
+}
+
+impl CborMerkleState {
+    pub fn new(inner: MerkleState) -> Self {
+        Self { inner }
+    }
+}
+
+impl Write for CborMerkleState {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn commit(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        let cbor_state_changes = state_changes
+            .iter()
+            .map(|state_change| match state_change {
+                StateChange::Delete { .. } => Ok(state_change.clone()),
+                StateChange::Set { key, value } => {
+                    let cbor_value = encode_cbor_value(value)
+                        .map_err(|err| StateWriteError::StorageError(Box::new(err)))?;
+                    Ok(StateChange::Set {
+                        key: key.to_string(),
+                        value: cbor_value,
+                    })
+                }
+            })
+            .collect::<Result<Vec<StateChange>, StateWriteError>>()?;
+        self.inner.commit(state_id, &cbor_state_changes)
+    }
+
+    fn compute_state_id(
+        &self,
+        state_id: &Self::StateId,
+        state_changes: &[StateChange],
+    ) -> Result<Self::StateId, StateWriteError> {
+        let cbor_state_changes = state_changes
+            .iter()
+            .map(|state_change| match state_change {
+                StateChange::Delete { .. } => Ok(state_change.clone()),
+                StateChange::Set { key, value } => {
+                    let cbor_value = encode_cbor_value(value)
+                        .map_err(|err| StateWriteError::StorageError(Box::new(err)))?;
+                    Ok(StateChange::Set {
+                        key: key.to_string(),
+                        value: cbor_value,
+                    })
+                }
+            })
+            .collect::<Result<Vec<StateChange>, StateWriteError>>()?;
+
+        self.inner.compute_state_id(state_id, &cbor_state_changes)
+    }
+}
+
+impl Read for CborMerkleState {
+    type StateId = String;
+    type Key = String;
+    type Value = Vec<u8>;
+
+    fn get(
+        &self,
+        state_id: &Self::StateId,
+        keys: &[Self::Key],
+    ) -> Result<HashMap<Self::Key, Self::Value>, StateReadError> {
+        let res = self.inner.get(state_id, keys)?;
+        res.into_iter()
+            .try_fold(HashMap::new(), |mut result, (key, value)| {
+                result.insert(
+                    key,
+                    decode_cbor_value(&value)
+                        .map_err(|err| StateReadError::StorageError(Box::new(err)))?,
+                );
+                Ok(result)
+            })
+    }
+
+    fn clone_box(&self) -> Box<dyn Read<StateId = String, Key = String, Value = Vec<u8>>> {
+        Box::new(Clone::clone(self))
     }
 }
 


### PR DESCRIPTION
This is required for backwards compatibility with existing sawtooth
state

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>