### PR TITLE
Add 'list transactions' to sawtooth client

### DIFF
--- a/libsawtooth/src/client/mod.rs
+++ b/libsawtooth/src/client/mod.rs
@@ -27,6 +27,13 @@ pub trait SawtoothClient {
     fn list_batches(
         &self,
     ) -> Result<Box<dyn Iterator<Item = Result<Batch, SawtoothClientError>>>, SawtoothClientError>;
+    /// Get all existing transactions in the current blockchain.
+    fn list_transactions(
+        &self,
+    ) -> Result<
+        Box<dyn Iterator<Item = Result<Transaction, SawtoothClientError>>>,
+        SawtoothClientError,
+    >;
 }
 
 /// A struct that represents a batch.

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -126,7 +126,7 @@ impl BatchIter {
                 SawtoothClientError::new_with_source("request failed", err.into())
             })?;
 
-            let page: Page = response.json().map_err(|err| {
+            let page: BatchPage = response.json().map_err(|err| {
                 SawtoothClientError::new_with_source(
                     "failed to deserialize response body",
                     err.into(),
@@ -218,7 +218,7 @@ impl Iterator for TransactionIter {
 
 /// A struct that represents a page of batches, used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-struct Page {
+struct BatchPage {
     data: Vec<Batch>,
     next: Option<String>,
 }

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -86,6 +86,17 @@ impl SawtoothClient for RestApiSawtoothClient {
 
         Ok(Box::new(BatchIter::new(&url).unwrap()))
     }
+    /// List all transactions in the current blockchain.
+    fn list_transactions(
+        &self,
+    ) -> Result<
+        Box<dyn Iterator<Item = Result<ClientTransaction, SawtoothClientError>>>,
+        SawtoothClientError,
+    > {
+        let url = format!("{}/transactions", &self.url);
+
+        Ok(Box::new(TransactionIter::new(&url).unwrap()))
+    }
 }
 
 /// Iterator used for parsing and deserializing batches.
@@ -148,10 +159,74 @@ impl Iterator for BatchIter {
     }
 }
 
+/// Iterator used for parsing and deserializing transactions.
+struct TransactionIter {
+    next: Option<String>,
+    cache: VecDeque<Transaction>,
+}
+
+impl TransactionIter {
+    /// Create a new 'TransactionIter' which will make a call to the REST API and load the initial
+    /// cache with the first page of transactions.
+    fn new(url: &str) -> Result<Self, SawtoothClientError> {
+        let mut new_iter = Self {
+            next: Some(url.to_string()),
+            cache: VecDeque::with_capacity(0),
+        };
+        new_iter.reload_cache()?;
+        Ok(new_iter)
+    }
+
+    /// If another page of transactions exisits, use the 'next' url from the current page and
+    /// reload the cache with the next page of transactions.
+    fn reload_cache(&mut self) -> Result<(), SawtoothClientError> {
+        if let Some(url) = &self.next.take() {
+            let request = Client::new().get(url);
+            let response = request.send().map_err(|err| {
+                SawtoothClientError::new_with_source("request failed", err.into())
+            })?;
+
+            let page: TransactionPage = response.json().map_err(|err| {
+                SawtoothClientError::new_with_source(
+                    "failed to deserialize response body",
+                    err.into(),
+                )
+            })?;
+
+            self.cache = page.data.into();
+
+            self.next = page.next;
+        }
+        Ok(())
+    }
+}
+
+impl Iterator for TransactionIter {
+    type Item = Result<ClientTransaction, SawtoothClientError>;
+    /// Return the next transaction from the cache, if the cache is empty reload it.
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.cache.is_empty() && self.next.is_some() {
+            if let Err(err) = self.reload_cache() {
+                return Some(Err(err));
+            }
+        };
+        let front = self.cache.pop_front()?;
+        let transaction: ClientTransaction = front.into();
+        Some(Ok(transaction))
+    }
+}
+
 /// A struct that represents a page of batches, used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
 pub struct Page {
     data: Vec<Batch>,
+    next: Option<String>,
+}
+
+/// A struct that represents a page of transactions, used for deserializing JSON objects.
+#[derive(Debug, Deserialize)]
+struct TransactionPage {
+    data: Vec<Transaction>,
     next: Option<String>,
 }
 

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -218,7 +218,7 @@ impl Iterator for TransactionIter {
 
 /// A struct that represents a page of batches, used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-pub struct Page {
+struct Page {
     data: Vec<Batch>,
     next: Option<String>,
 }
@@ -232,31 +232,31 @@ struct TransactionPage {
 
 /// A struct that represents a batch, used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-pub struct Batch {
-    pub header: Header,
-    pub header_signature: String,
-    pub trace: bool,
-    pub transactions: Vec<Transaction>,
+struct Batch {
+    header: Header,
+    header_signature: String,
+    trace: bool,
+    transactions: Vec<Transaction>,
 }
 
 /// A struct that represents a header in a batch, used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-pub struct Header {
+struct Header {
     signer_public_key: String,
     transaction_ids: Vec<String>,
 }
 
 /// A struct that represents a transaction, used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-pub struct Transaction {
+struct Transaction {
     header: TransactionHeader,
-    pub header_signature: String,
+    header_signature: String,
     payload: String,
 }
 
 /// A struct that represents a header in a transaction, used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-pub struct TransactionHeader {
+struct TransactionHeader {
     batcher_public_key: String,
     dependencies: Vec<String>,
     family_name: String,
@@ -271,7 +271,7 @@ pub struct TransactionHeader {
 /// A struct that represents the data returned by the REST API when retrieving a single batch.
 /// Used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-pub struct SingleBatch {
+struct SingleBatch {
     data: Batch,
 }
 


### PR DESCRIPTION
Add the 'list transactions' function to the sawtooth client and implement it for the REST API backed client. The function retrieves all transactions from the current blockchain.

Change the 'Page' struct to have a more accurate name, 'BatchPage'. Batch, transaction, block and state will each need their own page struct for deserializing the json object returned by the REST API. Logically they should all be named '_type_ Page'.

Make all client::rest deserialization structs private.