### PR TITLE
Add 'list blocks' to sawtooth client

### DIFF
--- a/libsawtooth/src/client/mod.rs
+++ b/libsawtooth/src/client/mod.rs
@@ -34,6 +34,10 @@ pub trait SawtoothClient {
         Box<dyn Iterator<Item = Result<Transaction, SawtoothClientError>>>,
         SawtoothClientError,
     >;
+    /// Get all existing blocks in the current blockchain.
+    fn list_blocks(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Result<Block, SawtoothClientError>>>, SawtoothClientError>;
 }
 
 /// A struct that represents a batch.
@@ -66,4 +70,19 @@ pub struct TransactionHeader {
     pub outputs: Vec<String>,
     pub payload_sha512: String,
     pub signer_public_key: String,
+}
+#[derive(Debug)]
+pub struct Block {
+    pub header: BlockHeader,
+    pub header_signature: String,
+    pub batches: Vec<Batch>,
+}
+#[derive(Debug)]
+pub struct BlockHeader {
+    pub batch_ids: Vec<String>,
+    pub block_num: String,
+    pub consensus: String,
+    pub previous_block_id: String,
+    pub signer_public_key: String,
+    pub state_root_hash: String,
 }


### PR DESCRIPTION
The 'list blocks' function is added to the sawtooth client and implemented for the REST API backed client. The 'list blocks' function retrieves all blocks from the current blockchain.

An iterator with generic type is created to minimize code volume. The iterator can be used for any of the 'list' functions that require a paging iterator in the REST API backed sawtooth client. This eliminates the need for a separate paged iterator for each data type.