### PR TITLE
Add 'get transaction' to sawtooth client

### DIFF
--- a/libsawtooth/src/client/mod.rs
+++ b/libsawtooth/src/client/mod.rs
@@ -27,6 +27,11 @@ pub trait SawtoothClient {
     fn list_batches(
         &self,
     ) -> Result<Box<dyn Iterator<Item = Result<Batch, SawtoothClientError>>>, SawtoothClientError>;
+    /// Get a single transaction in the current blockchain.
+    fn get_transaction(
+        &self,
+        transaction_id: String,
+    ) -> Result<Option<Transaction>, SawtoothClientError>;
     /// Get all existing transactions in the current blockchain.
     fn list_transactions(
         &self,

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -348,11 +348,16 @@ impl Into<ClientBlockHeader> for BlockHeader {
 /// Used for deserializing error responses from the Sawtooth REST API.
 #[derive(Debug, Deserialize)]
 struct ErrorResponse {
+    error: ErrData,
+}
+
+#[derive(Debug, Deserialize)]
+struct ErrData {
     message: String,
 }
 
 impl std::fmt::Display for ErrorResponse {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.message)
+        write!(f, "{}", self.error.message)
     }
 }

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -63,6 +63,16 @@ impl SawtoothClient for RestApiSawtoothClient {
             |item: Result<Batch, _>| item.map(|batch| batch.into()),
         )))
     }
+    /// Get the transaction with the given transaction_id from the current blockchain
+    fn get_transaction(
+        &self,
+        transaction_id: String,
+    ) -> Result<Option<ClientTransaction>, SawtoothClientError> {
+        let url = format!("{}/transactions/{}", &self.url, &transaction_id);
+        let error_msg = &format!("unable to get transaction {}", transaction_id);
+
+        Ok(get::<Transaction>(&url, error_msg)?.map(|txn| txn.into()))
+    }
     /// List all transactions in the current blockchain.
     fn list_transactions(
         &self,

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -52,7 +52,7 @@ impl SawtoothClient for RestApiSawtoothClient {
             .map_err(|err| SawtoothClientError::new_with_source("request failed", err.into()))?;
 
         if response.status().is_success() {
-            let batch: SingleBatch = response.json().map_err(|err| {
+            let batch: Single<Batch> = response.json().map_err(|err| {
                 SawtoothClientError::new_with_source(
                     "failed to deserialize response body",
                     err.into(),
@@ -246,11 +246,12 @@ struct BlockHeader {
     state_root_hash: String,
 }
 
-/// A struct that represents the data returned by the REST API when retrieving a single batch.
+/// A struct that represents the data returned by the REST API when retrieving a single item.
 /// Used for deserializing JSON objects.
 #[derive(Debug, Deserialize)]
-struct SingleBatch {
-    data: Batch,
+struct Single<T: Sized> {
+    #[serde(bound(deserialize = "T: Deserialize<'de>"))]
+    data: T,
 }
 
 impl Into<ClientBatch> for Batch {


### PR DESCRIPTION
The 'get transaction' function is added to the sawtooth client and implemented for the REST API backed client. The function retrieves a single transaction with the given transaction_id from the current blockchain.

A generic struct representing a single object (Batch, Transaction, Block, etc.) is created. The struct is used for deserializing JSON objects returned by the REST API. This struct can be used by any of the 'get' functions. The 'get batch' function was updated to use this new struct.