### PR TITLE
Add 'get block' to sawtooth client

### DIFF
--- a/libsawtooth/src/client/mod.rs
+++ b/libsawtooth/src/client/mod.rs
@@ -39,6 +39,8 @@ pub trait SawtoothClient {
         Box<dyn Iterator<Item = Result<Transaction, SawtoothClientError>>>,
         SawtoothClientError,
     >;
+    /// Get a single block in the current blockchain.
+    fn get_block(&self, block_id: String) -> Result<Option<Block>, SawtoothClientError>;
     /// Get all existing blocks in the current blockchain.
     fn list_blocks(
         &self,

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -86,6 +86,13 @@ impl SawtoothClient for RestApiSawtoothClient {
             |item: Result<Transaction, _>| item.map(|txn| txn.into()),
         )))
     }
+    /// Get the block with the given block_id from the current blockchain
+    fn get_block(&self, block_id: String) -> Result<Option<ClientBlock>, SawtoothClientError> {
+        let url = format!("{}/blocks/{}", &self.url, &block_id);
+        let error_msg = &format!("unable to get block {}", block_id);
+
+        Ok(get::<Block>(&url, error_msg)?.map(|block| block.into()))
+    }
     /// List all blocks in the current blockchain
     fn list_blocks(
         &self,


### PR DESCRIPTION
The 'get block' function is added to the sawtooth client and implemented for the REST API backed client. The function retrieves a single block with the given block_id from the current blockchain.