### PR TITLE
Add 'list states' to sawtooth client

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -24,6 +24,7 @@ description = """\
 """
 
 [dependencies]
+base64 = { version = "0.12", optional = true }
 cbor-codec = { version = "0.7", optional = true }
 cylinder = "0.1"
 hex = "0.4"
@@ -66,7 +67,7 @@ experimental = [
 
 btree-store = ["stores"]
 client = []
-client-rest = ["client", "reqwest", "serde"]
+client-rest = ["base64", "client", "reqwest", "serde"]
 lmdb-store = ["lmdb-zero", "stores"]
 receipt-store = ["stores"]
 redis-store = ["redis", "stores"]

--- a/libsawtooth/src/client/mod.rs
+++ b/libsawtooth/src/client/mod.rs
@@ -45,6 +45,10 @@ pub trait SawtoothClient {
     fn list_blocks(
         &self,
     ) -> Result<Box<dyn Iterator<Item = Result<Block, SawtoothClientError>>>, SawtoothClientError>;
+    /// Get all existing state entries in the current blockchain.
+    fn list_states(
+        &self,
+    ) -> Result<Box<dyn Iterator<Item = Result<State, SawtoothClientError>>>, SawtoothClientError>;
 }
 
 /// A struct that represents a batch.
@@ -92,4 +96,9 @@ pub struct BlockHeader {
     pub previous_block_id: String,
     pub signer_public_key: String,
     pub state_root_hash: String,
+}
+#[derive(Debug)]
+pub struct State {
+    pub address: String,
+    pub data: Vec<u8>,
 }


### PR DESCRIPTION
The 'list states' function and related structs are added to the sawtooth client and implemented for the REST API backed client. The function retrieves all state entries from the current blockchain.