### PR TITLE
Add struct for deserializing paged data

### DIFF
--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -196,7 +196,7 @@ where
 
             self.cache = page.data.into();
 
-            self.next = page.next.map(String::from);
+            self.next = page.paging.next.map(String::from);
         }
         Ok(())
     }
@@ -223,6 +223,11 @@ where
 struct Page<T: Sized> {
     #[serde(bound(deserialize = "T: Deserialize<'de>"))]
     data: Vec<T>,
+    paging: PageInfo,
+}
+
+#[derive(Debug, Deserialize)]
+struct PageInfo {
     next: Option<String>,
 }
 


### PR DESCRIPTION
When a call to the REST API was made and multiple pages of data exist, the link to the next page of items wasn't being properly deserialized into the 'next' field of the Page struct. This is due to how the next field is nested in the JSON object. The addition of the PageInfo struct resolves the problem.

The generic paging iterator is updated to use this new struct.