### PR TITLE
Fix underflow in commit store

### DIFF
--- a/libsawtooth/src/journal/commit_store.rs
+++ b/libsawtooth/src/journal/commit_store.rs
@@ -532,7 +532,7 @@ impl Iterator for CommitStoreByHeightIterator {
         if block.is_some() {
             self.next = match self.direction {
                 ByHeightDirection::Increasing => self.next.map(|next| next + 1),
-                ByHeightDirection::Decreasing => self.next.map(|next| next - 1),
+                ByHeightDirection::Decreasing => self.next.and_then(|next| next.checked_sub(1)),
             }
         }
         block


### PR DESCRIPTION
Fixes a u64 underflow in the commit store by using `checked_sub` instead
of the subtraction operator.

Signed-off-by: Logan Seeley <seeley@bitwise.io>