### PR TITLE
Add 'submit batches' to sawtooth client

### DIFF
--- a/libsawtooth/src/client/mod.rs
+++ b/libsawtooth/src/client/mod.rs
@@ -59,6 +59,19 @@ pub trait SawtoothClient {
         batch_ids: Vec<&str>,
         wait: Option<Duration>,
     ) -> Result<Option<Vec<Status>>, SawtoothClientError>;
+    /// Send one or more batches to the validator.
+    ///
+    /// # Arguments
+    ///
+    /// * `filename` - The name of the file containing the batches to be submitted
+    /// * `wait` - The time, in seconds, to wait for batches to submit
+    /// * `size_limit` - The maximum batch list size, batches are split for processing if they exceed this size
+    fn submit_batches(
+        &self,
+        filename: String,
+        wait: Option<Duration>,
+        size_limit: usize,
+    ) -> Result<Vec<String>, SawtoothClientError>;
 }
 
 /// A struct that represents a batch.

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -12,7 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[cfg(any(feature = "lmdb-store", feature = "validator-internals"))]
+#[cfg(any(
+    feature = "lmdb-store",
+    feature = "validator-internals",
+    feature = "client"
+))]
 #[macro_use]
 extern crate log;
 #[cfg(feature = "validator-internals")]


### PR DESCRIPTION
The 'submit batches' command is added to the sawtooth client and implemented for the REST API backed client. This function sends one or more batches to the sawtooth REST API to be submitted by the validator.