### PR TITLE
Fix clippy error derive_ord_xor_partial_ord for PruneCandidate

### DIFF
--- a/libsawtooth/src/state/state_pruning_manager.rs
+++ b/libsawtooth/src/state/state_pruning_manager.rs
@@ -32,12 +32,18 @@ pub struct StatePruningManager {
     state_database: LmdbDatabase,
 }
 
-#[derive(Eq, PartialEq, Debug, Ord)]
+#[derive(Eq, PartialEq, Debug)]
 struct PruneCandidate(u64, Vec<u8>);
+
+impl Ord for PruneCandidate {
+    fn cmp(&self, other: &PruneCandidate) -> Ordering {
+        Ordering::reverse(self.0.cmp(&other.0))
+    }
+}
 
 impl PartialOrd for PruneCandidate {
     fn partial_cmp(&self, other: &PruneCandidate) -> Option<Ordering> {
-        Some(Ordering::reverse(self.0.cmp(&other.0)))
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
From Clippy documentation:

Implementations of PartialEq, PartialOrd, and Ord must agree
with each other. It’s easy to accidentally make them disagree
by deriving some of the traits and manually implementing others.

If your type is Ord, you can implement partial_cmp by using cmp

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>