### PR TITLE
Use Message::parse_from_bytes instead of protobuf::parse_from_bytes

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -32,7 +32,7 @@ log = "0.4"
 lmdb-zero = { version = "0.4", optional = true }
 metrics = { version = "0.12", features = ["std"], optional = true }
 openssl = { version = "0.10", optional = true }
-protobuf = "2"
+protobuf = "2.19"
 redis = { version = "0.13.0", default-features = false, optional = true }
 reqwest = { version = "0.10", optional = true, features = ["blocking", "json"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/libsawtooth/src/client/rest.rs
+++ b/libsawtooth/src/client/rest.rs
@@ -212,10 +212,9 @@ impl SawtoothClient for RestApiSawtoothClient {
             SawtoothClientError::new_with_source("failed to open batch file", err.into())
         })?;
 
-        let batch_list: BatchList =
-            protobuf::parse_from_reader(&mut batch_file).map_err(|err| {
-                SawtoothClientError::new_with_source("unable to parse file contents", err.into())
-            })?;
+        let batch_list: BatchList = Message::parse_from_reader(&mut batch_file).map_err(|err| {
+            SawtoothClientError::new_with_source("unable to parse file contents", err.into())
+        })?;
         let len = batch_list.batches.len();
         let batch_ids = batch_list
             .batches

--- a/libsawtooth/src/protocol/batch.rs
+++ b/libsawtooth/src/protocol/batch.rs
@@ -28,7 +28,7 @@ use crate::protos::{
 
 impl FromBytes<Batch> for Batch {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<BatchProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Batch from bytes".to_string(),
@@ -83,7 +83,7 @@ impl IntoProto<BatchProto> for Batch {}
 
 impl FromBytes<Vec<Batch>> for Vec<Batch> {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<BatchList>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Vec<Batch> from bytes".to_string(),
@@ -132,7 +132,7 @@ impl IntoProto<BatchList> for Vec<Batch> {}
 
 impl FromBytes<BatchHeader> for BatchHeader {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<BatchHeaderProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get BatchHeader from bytes".to_string(),

--- a/libsawtooth/src/protocol/block.rs
+++ b/libsawtooth/src/protocol/block.rs
@@ -72,7 +72,7 @@ impl std::fmt::Display for Block {
 
 impl FromBytes<Block> for Block {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<BlockProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Block from bytes".to_string(),
@@ -179,7 +179,7 @@ impl std::fmt::Display for BlockHeader {
 
 impl FromBytes<BlockHeader> for BlockHeader {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<BlockHeaderProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get BlockHeader from bytes".to_string(),

--- a/libsawtooth/src/protocol/block_info.rs
+++ b/libsawtooth/src/protocol/block_info.rs
@@ -76,7 +76,7 @@ impl BlockInfo {
 
 impl FromBytes<BlockInfo> for BlockInfo {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<BlockInfoTxnProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get BlockInfo from bytes".to_string(),

--- a/libsawtooth/src/protocol/genesis.rs
+++ b/libsawtooth/src/protocol/genesis.rs
@@ -43,7 +43,7 @@ impl GenesisData {
 
 impl FromBytes<GenesisData> for GenesisData {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<GenesisDataProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get GenesisData from bytes".to_string(),

--- a/libsawtooth/src/protocol/identity.rs
+++ b/libsawtooth/src/protocol/identity.rs
@@ -48,7 +48,7 @@ impl Policy {
 
 impl FromBytes<Policy> for Policy {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<PolicyProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Policy from bytes".to_string(),
@@ -108,7 +108,7 @@ impl IntoProto<PolicyProto> for Policy {}
 
 impl FromBytes<Vec<Policy>> for Vec<Policy> {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<PolicyList>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Vec<Policy> from bytes".to_string(),
@@ -164,7 +164,7 @@ pub enum Permission {
 
 impl FromBytes<Permission> for Permission {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<Policy_Entry>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Permission from bytes".to_string(),
@@ -275,7 +275,7 @@ impl Role {
 
 impl FromBytes<Role> for Role {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<RoleProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Role from bytes".to_string(),
@@ -324,7 +324,7 @@ impl IntoProto<RoleProto> for Role {}
 
 impl FromBytes<Vec<Role>> for Vec<Role> {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<RoleList>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Vec<Role> from bytes".to_string(),

--- a/libsawtooth/src/protocol/setting.rs
+++ b/libsawtooth/src/protocol/setting.rs
@@ -45,7 +45,7 @@ impl Setting {
 
 impl FromBytes<Setting> for Setting {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<Setting_Entry>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Setting from bytes".to_string(),
@@ -93,7 +93,7 @@ impl IntoProto<Setting_Entry> for Setting {}
 
 impl FromBytes<Vec<Setting>> for Vec<Setting> {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<SettingProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Vec<Setting> from bytes".to_string(),

--- a/libsawtooth/src/protocol/transaction.rs
+++ b/libsawtooth/src/protocol/transaction.rs
@@ -28,7 +28,7 @@ use crate::protos::{
 
 impl FromBytes<Transaction> for Transaction {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<TransactionProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get Transaction from bytes".to_string(),
@@ -81,7 +81,7 @@ impl IntoProto<TransactionProto> for Transaction {}
 
 impl FromBytes<TransactionHeader> for TransactionHeader {
     fn from_bytes(bytes: &[u8]) -> Result<Self, ProtoConversionError> {
-        protobuf::parse_from_bytes::<TransactionHeaderProto>(bytes)
+        Message::parse_from_bytes(bytes)
             .map_err(|_| {
                 ProtoConversionError::SerializationError(
                     "Unable to get TransactionHeader from bytes".to_string(),


### PR DESCRIPTION
protobuf::parse_from_bytes is deprecated.
Also update version of protobuf used to 2.19.

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>