### PR TITLE
Fix clippy unnecessary_wraps lint warnings

### DIFF
--- a/libsawtooth/src/journal/block_store.rs
+++ b/libsawtooth/src/journal/block_store.rs
@@ -93,7 +93,9 @@ impl BlockStore for InMemoryBlockStore {
         self.state
             .lock()
             .expect("The mutex is poisoned")
-            .put(blocks)
+            .put(blocks);
+
+        Ok(())
     }
 
     fn iter<'a>(&'a self) -> Result<Box<dyn Iterator<Item = BlockPair> + 'a>, BlockStoreError> {
@@ -143,7 +145,7 @@ impl InMemoryBlockStoreState {
         Ok(blocks.collect())
     }
 
-    fn put(&mut self, blocks: Vec<BlockPair>) -> Result<(), BlockStoreError> {
+    fn put(&mut self, blocks: Vec<BlockPair>) {
         blocks.into_iter().for_each(|block| {
             if block.header().block_num() > self.chain_head_num {
                 self.chain_head_id = block.block().header_signature().to_string();
@@ -153,7 +155,6 @@ impl InMemoryBlockStoreState {
             self.block_by_block_id
                 .insert(block.block().header_signature().to_string(), block);
         });
-        Ok(())
     }
 }
 

--- a/libsawtooth/src/journal/publisher/chain_head_lock.rs
+++ b/libsawtooth/src/journal/publisher/chain_head_lock.rs
@@ -54,16 +54,11 @@ impl<'a> ChainHeadGuard<'a> {
         committed_batches: Vec<BatchPair>,
         uncommitted_batches: Vec<BatchPair>,
     ) {
-        if let Err(err) = BlockPublisher::on_chain_updated(
+        BlockPublisher::on_chain_updated(
             &mut self.state,
             chain_head,
             committed_batches,
             uncommitted_batches,
-        ) {
-            error!(
-                "An unexpected error occurred when notifying the publisher of a chain update: {}",
-                err
-            );
-        }
+        );
     }
 }

--- a/libsawtooth/src/journal/publisher/mod.rs
+++ b/libsawtooth/src/journal/publisher/mod.rs
@@ -163,13 +163,11 @@ impl BlockPublisher {
         new_chain_head: BlockPair,
         committed_batches: Vec<BatchPair>,
         uncommitted_batches: Vec<BatchPair>,
-    ) -> Result<(), BlockPublisherError> {
+    ) {
         // Use the new chain head as a sample for calculating the upper bound of the batch pool
         pending_batches.update_limit(new_chain_head.block().batches().len());
         // Rebuild the pending batch pool based on the batches that were committed and uncommitted
         pending_batches.rebuild(Some(committed_batches), Some(uncommitted_batches));
-
-        Ok(())
     }
 
     /// Starts a new block on top of an existing block and schedules as many transactions as the

--- a/libsawtooth/src/store/lmdb.rs
+++ b/libsawtooth/src/store/lmdb.rs
@@ -193,7 +193,7 @@ impl<
             self.index_to_key_db.clone(),
             self.main_db.clone(),
             None,
-        )?;
+        );
 
         Ok(Box::new(iter))
     }
@@ -207,7 +207,7 @@ impl<
             self.index_to_key_db.clone(),
             self.main_db.clone(),
             Some(range),
-        )?;
+        );
 
         Ok(Box::new(iter))
     }
@@ -356,7 +356,7 @@ impl<V: FromBytes, I: AsBytes + FromBytes + PartialEq + PartialOrd> LmdbOrderedS
         index_to_key_db: Arc<lmdb::Database<'static>>,
         main_db: Arc<lmdb::Database<'static>>,
         range: Option<OrderedStoreRange<I>>,
-    ) -> Result<Self, OrderedStoreError> {
+    ) -> Self {
         let mut iter = Self {
             env,
             index_to_key_db,
@@ -370,7 +370,7 @@ impl<V: FromBytes, I: AsBytes + FromBytes + PartialEq + PartialOrd> LmdbOrderedS
             error!("Failed to load iterator's initial cache: {}", err);
         }
 
-        Ok(iter)
+        iter
     }
 
     fn reload_cache(&mut self) -> Result<(), String> {
@@ -493,8 +493,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 None,
-            )
-            .expect("failed to create iter for all entries");
+            );
 
             assert_eq!(
                 all_entries.collect::<Vec<_>>(),
@@ -507,8 +506,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((2..).into()),
-            )
-            .expect("failed to create iter for entries from 2");
+            );
 
             assert_eq!(from_2.collect::<Vec<_>>(), vec![2u8, 3u8, 4u8, 5u8]);
 
@@ -518,8 +516,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((..5).into()), // upper bound is exclusive
-            )
-            .expect("failed to create iter for entries up to 4");
+            );
 
             assert_eq!(up_to_4.collect::<Vec<_>>(), vec![1u8, 2u8, 3u8, 4u8]);
 
@@ -529,8 +526,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((2..5).into()), // upper bound is exclusive
-            )
-            .expect("failed to create iter for entries from 2 to 4");
+            );
 
             assert_eq!(from_2_to_4.collect::<Vec<_>>(), vec![2u8, 3u8, 4u8]);
 
@@ -540,8 +536,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((1..).into()),
-            )
-            .expect("failed to create iter for entries from 1 (inclusive)");
+            );
 
             assert_eq!(
                 from_1_inclusive.collect::<Vec<_>>(),
@@ -554,8 +549,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((0..).into()),
-            )
-            .expect("failed to create iter for entries from 0 (inclusive)");
+            );
 
             assert_eq!(
                 from_0_inclusive.collect::<Vec<_>>(),
@@ -571,8 +565,7 @@ mod tests {
                     start: Bound::Excluded(1),
                     end: Bound::Unbounded,
                 }),
-            )
-            .expect("failed to create iter for entries from 1 (exclusive)");
+            );
 
             assert_eq!(
                 from_1_exclusive.collect::<Vec<_>>(),
@@ -585,8 +578,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((0..).into()),
-            )
-            .expect("failed to create iter for entries from 0 (exclusive)");
+            );
 
             assert_eq!(
                 from_0_exclusive.collect::<Vec<_>>(),
@@ -599,8 +591,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some(std::ops::RangeToInclusive { end: 5 }.into()),
-            )
-            .expect("failed to create iter for entries up to 5 (inclusive)");
+            );
 
             assert_eq!(
                 up_to_5_inclusive.collect::<Vec<_>>(),
@@ -613,8 +604,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some(std::ops::RangeToInclusive { end: 6 }.into()),
-            )
-            .expect("failed to create iter for entries up to 6 (inclusive)");
+            );
 
             assert_eq!(
                 up_to_6_inclusive.collect::<Vec<_>>(),
@@ -627,8 +617,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((..5).into()),
-            )
-            .expect("failed to create iter for entries up to 5 (exclusive)");
+            );
 
             assert_eq!(
                 up_to_5_exclusive.collect::<Vec<_>>(),
@@ -641,8 +630,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 Some((..6).into()),
-            )
-            .expect("failed to create iter for entries up to 6 (exclusive)");
+            );
 
             assert_eq!(
                 up_to_6_exclusive.collect::<Vec<_>>(),
@@ -674,8 +662,7 @@ mod tests {
                 store.index_to_key_db.clone(),
                 store.main_db.clone(),
                 None,
-            )
-            .expect("failed to create iter");
+            );
 
             assert_eq!(iter.cache.len(), ITER_CACHE_SIZE);
 


### PR DESCRIPTION
This change addresses a lint where private functions are returning a result, but only ever return Ok. It is fixed by removing the Result from the return definition.

These appeared in Rust 1.50.0.
