### PR TITLE
Replace iter().count() with len() on BTreeMap

### DIFF
--- a/libsawtooth/src/store/btree.rs
+++ b/libsawtooth/src/store/btree.rs
@@ -93,8 +93,7 @@ impl<
             .lock()
             .map_err(|err| OrderedStoreError::LockPoisoned(err.to_string()))?
             .main_store
-            .iter()
-            .count()
+            .len()
             .try_into()
             .map_err(|err| OrderedStoreError::Internal(Box::new(err)))
     }


### PR DESCRIPTION
This fixes a clippy error introduced in Rust 1.52

Signed-off-by: Andrea Gunderson <agunde@bitwise.io>