### PR TITLE
Fix SQLite receipt store indexing

### DIFF
--- a/libsawtooth/src/migrations/diesel/sqlite/migrations/2021-08-04-163100_receipt_store/up.sql
+++ b/libsawtooth/src/migrations/diesel/sqlite/migrations/2021-08-04-163100_receipt_store/up.sql
@@ -15,7 +15,7 @@
 
 CREATE TABLE IF NOT EXISTS transaction_receipt (
     transaction_id              TEXT PRIMARY KEY,
-    idx                         INTEGER NOT NULL
+    idx                         INTEGER NOT NULL UNIQUE
 );
 
 CREATE TABLE IF NOT EXISTS invalid_transaction_result (

--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -257,8 +257,8 @@ pub mod tests {
                 .expect("Unable to add receipts");
 
             let first_receipt = receipt_store
-                .get_txn_receipt_by_index(0)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(1)
+                .expect("failed to get transaction receipt at index 1");
 
             match first_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { events, .. } => {
@@ -283,8 +283,8 @@ pub mod tests {
             }
 
             let second_receipt = receipt_store
-                .get_txn_receipt_by_index(1)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(2)
+                .expect("failed to get transaction receipt at index 2");
 
             match second_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { events, .. } => {
@@ -548,8 +548,8 @@ pub mod tests {
                 .expect("Unable to add receipts");
 
             let first_receipt = receipt_store
-                .remove_txn_receipt_by_index(0)
-                .expect("failed to get transaction receipt at idndex 0");
+                .remove_txn_receipt_by_index(1)
+                .expect("failed to get transaction receipt at index 1");
 
             match first_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { events, .. } => assert_eq!(
@@ -560,7 +560,7 @@ pub mod tests {
             }
 
             assert!(receipt_store
-                .get_txn_receipt_by_index(0)
+                .get_txn_receipt_by_index(1)
                 .expect("error getting receipt")
                 .is_none());
 
@@ -634,8 +634,8 @@ pub mod tests {
                 .expect("Unable to add receipts");
 
             let first_receipt = receipt_store
-                .get_txn_receipt_by_index(0)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(1)
+                .expect("failed to get transaction receipt at index 1");
 
             match first_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { events, .. } => {
@@ -653,8 +653,8 @@ pub mod tests {
             }
 
             let second_receipt = receipt_store
-                .get_txn_receipt_by_index(1)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(2)
+                .expect("failed to get transaction receipt at index 2");
 
             match second_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { events, .. } => {
@@ -722,8 +722,8 @@ pub mod tests {
                 .expect("Unable to add receipts");
 
             let first_receipt = receipt_store
-                .get_txn_receipt_by_index(0)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(1)
+                .expect("failed to get transaction receipt at index 1");
 
             match first_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { events, .. } => {
@@ -733,8 +733,8 @@ pub mod tests {
             }
 
             let second_receipt = receipt_store
-                .get_txn_receipt_by_index(1)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(2)
+                .expect("failed to get transaction receipt at index 2");
 
             match second_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { events, .. } => {
@@ -799,8 +799,8 @@ pub mod tests {
                 .expect("Unable to add receipts");
 
             let first_receipt = receipt_store
-                .get_txn_receipt_by_index(0)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(1)
+                .expect("failed to get transaction receipt at index 1");
 
             match first_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { state_changes, .. } => {
@@ -810,8 +810,8 @@ pub mod tests {
             }
 
             let second_receipt = receipt_store
-                .get_txn_receipt_by_index(1)
-                .expect("failed to get transaction receipt at idndex 0");
+                .get_txn_receipt_by_index(2)
+                .expect("failed to get transaction receipt at index 2");
 
             match second_receipt.unwrap().transaction_result {
                 TransactionResult::Valid { state_changes, .. } => {


### PR DESCRIPTION
Previously the way that the index value was being assigned to the transaction receipt entry when adding new transaction receipts to the store did not guarantee uniqueness. This PR updates that process to retrieve the index of the most recently added transaction receipt and increment it by one to get the index of each new transaction receipt being added to the database.

This PR also adds a uniqueness constraint to the idx field of the `transaction_receipt` table.