### PR TITLE
SQLite/PostgreSQL receipt store stabilization changes

### DIFF
--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -15,7 +15,13 @@
  * ------------------------------------------------------------------------------
  */
 
-// ! A Diesel implementation of `ReceiptStore`.
+//! A [`Diesel`](https://crates.io/crates/diesel) backend for [`ReceiptStore`].
+//!
+//! This module contains the [`DieselReceiptStore`], which provides an implementation
+//! of the [`ReceiptStore`] trait.
+//!
+//! [`DieselReceiptStore`]: struct.DieselReceiptStore.html
+//! [`ReceiptStore`]: trait.ReceiptStore.html
 
 pub mod models;
 mod operations;

--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -480,7 +480,7 @@ pub mod tests {
     /// 1. Create a new `DieselReceiptStore`
     /// 2. Generate 10 transaction receipts and add them to the receipt store
     /// 3. Call `list_receipts_since` on the receipt store, passing in an id to indicate all
-    ///    receipts added since that reciept should be listed
+    ///    receipts added since that receipt should be listed
     /// 4. Check that the receipts are returned in order and that various fields
     ///    contain the expected values
     /// 5. Check that the number of receipts returned is 7

--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -956,6 +956,67 @@ pub mod tests {
         assert!(test_result.is_ok());
     }
 
+    /// Verify that all transaction receipts in a SQLite `DieselReceiptStore` are returned
+    /// in the correct order when added to the database one at a time
+    ///
+    /// 1. Create a new `DieselReceiptStore`
+    /// 2. Generate 20 transaction receipts and individually add the first 10 to the receipt store
+    /// 3. Add the remaining 10 transaction receipts at the same time in a vector
+    /// 4. Call `list_receipts_since` on the receipt store, passing in None to indicate all
+    ///    receipts should be listed
+    /// 5. Check that the receipts are returned in order and that various fields
+    ///    contain the expected values
+    /// 6. Check that the number of receipts returned is 20
+    #[test]
+    fn test_sqlite_list_receipts_order() {
+        let pool = create_connection_pool_and_migrate();
+
+        let receipt_store = DieselReceiptStore::new(pool);
+
+        let txn_receipts = create_txn_receipts(20);
+
+        for r in txn_receipts[0..10].to_vec() {
+            receipt_store
+                .add_txn_receipts(vec![r])
+                .expect("Unable to add individual receipt");
+        }
+
+        receipt_store
+            .add_txn_receipts(txn_receipts[10..].to_vec())
+            .expect("Unable to add remaining 10 receipts");
+
+        let all_receipts = receipt_store
+            .list_receipts_since(None)
+            .expect("failed to list all transaction receipts");
+
+        let mut total = 0;
+        for (i, receipt) in all_receipts.enumerate() {
+            match receipt.transaction_result {
+                TransactionResult::Valid { events, .. } => {
+                    assert_eq!(
+                        events[0].attributes[0],
+                        (format!("a{}", i), format!("b{}", i))
+                    );
+                    assert_eq!(
+                        events[0].attributes[1],
+                        (format!("c{}", i), format!("d{}", i))
+                    );
+                    assert_eq!(
+                        events[1].attributes[0],
+                        (format!("e{}", i), format!("f{}", i))
+                    );
+                    assert_eq!(
+                        events[1].attributes[1],
+                        (format!("g{}", i), format!("h{}", i))
+                    );
+                }
+                _ => panic!("transaction result should be valid"),
+            }
+            total += 1;
+        }
+        assert_eq!(total, 20);
+    }
+
     /// Creates a connection pool for an in-memory SQLite database with only a single connection
     /// available. Each connection is backed by a different in-memory SQLite database, so limiting
     /// the pool to a single connection ensures that the same DB is used for all operations.

--- a/libsawtooth/src/receipt/store/diesel/models.rs
+++ b/libsawtooth/src/receipt/store/diesel/models.rs
@@ -15,6 +15,8 @@
  * ------------------------------------------------------------------------------
  */
 
+//! Database representations used to implement a diesel backend for the `ReceiptStore`.
+
 use std::convert::TryFrom;
 use std::io::Write;
 

--- a/libsawtooth/src/receipt/store/diesel/models.rs
+++ b/libsawtooth/src/receipt/store/diesel/models.rs
@@ -198,7 +198,7 @@ where
         match i16::from_sql(bytes)? {
             1 => Ok(StateChangeTypeModel::Set),
             2 => Ok(StateChangeTypeModel::Delete),
-            int => Err(format!("Invalid circuit status {}", int).into()),
+            int => Err(format!("Invalid state change type {}", int).into()),
         }
     }
 }


### PR DESCRIPTION
Fix an error message in the `from_sql` method for `StateChangeTypeModel`. The method was copy pasted and the error message was not properly updated.