### PR TITLE
Fix sqlite receipt store test

### DIFF
--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -1003,7 +1003,10 @@ pub mod tests {
 
         let mut total = 0;
         for (i, receipt) in all_receipts.enumerate() {
-            match receipt.transaction_result {
+            match receipt
+                .expect("failed to get transaction receipt")
+                .transaction_result
+            {
                 TransactionResult::Valid { events, .. } => {
                     assert_eq!(
                         events[0].attributes[0],


### PR DESCRIPTION
Update one of the sqlite receipt store tests to work with updated
`list_receipts_since` method that now returns an iterator of
Result<TransactionReceipt, ReceiptStoreError> rather than just
TransactionReceipt

Signed-off-by: Isabel Tomb <tomb@bitwise.io>