### PR TITLE
Add experimental features to docs.rs

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -91,3 +91,9 @@ validator-internals = [
   "openssl",
   "uluru",
 ]
+
+[package.metadata.docs.rs]
+features = [
+    "stable",
+    "experimental"
+]


### PR DESCRIPTION
This change adds the experimental features to the list of features that will be used to generate the rust documentation on docs.rs.
