### PR TITLE
transact dependency update

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -38,7 +38,7 @@ protobuf = "2.23"
 redis = { version = "0.20", default-features = false, optional = true }
 reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-transact = "0.3"
+transact = "0.3.8"
 uluru = { version = "0.4", optional = true }
 
 [dev-dependencies]

--- a/libsawtooth/src/state/error.rs
+++ b/libsawtooth/src/state/error.rs
@@ -104,6 +104,9 @@ impl From<TransactStateDatabaseError> for StateDatabaseError {
             TransactStateDatabaseError::ChangeLogEncodingError(msg) => {
                 StateDatabaseError::ChangeLogEncodingError(msg)
             }
+            TransactStateDatabaseError::InternalError(err) => {
+                StateDatabaseError::Internal(InternalError::from_source(Box::new(err)))
+            }
             TransactStateDatabaseError::InvalidRecord => StateDatabaseError::InvalidRecord,
             TransactStateDatabaseError::InvalidHash(msg) => StateDatabaseError::InvalidHash(msg),
             TransactStateDatabaseError::InvalidChangeLogIndex(msg) => {

--- a/libsawtooth/src/state/error.rs
+++ b/libsawtooth/src/state/error.rs
@@ -23,12 +23,15 @@ use protobuf::ProtobufError;
 use transact::database::error::DatabaseError;
 use transact::state::merkle::StateDatabaseError as TransactStateDatabaseError;
 
+use crate::error::InternalError;
+
 #[derive(Debug)]
 pub enum StateDatabaseError {
     NotFound(String),
     DeserializationError(DecodeError),
     SerializationError(EncodeError),
     ChangeLogEncodingError(String),
+    Internal(InternalError),
     InvalidRecord,
     InvalidHash(String),
     #[allow(dead_code)]
@@ -51,6 +54,7 @@ impl fmt::Display for StateDatabaseError {
             StateDatabaseError::ChangeLogEncodingError(ref msg) => {
                 write!(f, "Unable to serialize change log entry: {}", msg)
             }
+            StateDatabaseError::Internal(ref err) => f.write_str(&err.to_string()),
             StateDatabaseError::InvalidRecord => write!(f, "A node was malformed"),
             StateDatabaseError::InvalidHash(ref msg) => {
                 write!(f, "The given hash is invalid: {}", msg)
@@ -76,6 +80,7 @@ impl Error for StateDatabaseError {
             StateDatabaseError::DeserializationError(ref err) => Some(err),
             StateDatabaseError::SerializationError(ref err) => Some(err),
             StateDatabaseError::ChangeLogEncodingError(_) => None,
+            StateDatabaseError::Internal(ref err) => Some(err),
             StateDatabaseError::InvalidRecord => None,
             StateDatabaseError::InvalidHash(_) => None,
             StateDatabaseError::InvalidChangeLogIndex(_) => None,


### PR DESCRIPTION
This change updates the transact dependency to a minimum of 0.3.8.

This is required to cover a new error variant added to its `StateDatabaseError`. It adds an analogous error variant to libsplinter's version of the error.