### PR TITLE
Add a `service_id` to the `DieselReceiptStore`

### DIFF
--- a/libsawtooth/src/migrations/diesel/postgres/migrations/2021-09-27-094150_receipt_store_service_id/down.sql
+++ b/libsawtooth/src/migrations/diesel/postgres/migrations/2021-09-27-094150_receipt_store_service_id/down.sql
@@ -1,0 +1,20 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE transaction_receipt 
+ADD CONSTRAINT transaction_receipt_idx_key UNIQUE (idx);
+
+ALTER TABLE transaction_receipt
+DROP COLUMN service_id;

--- a/libsawtooth/src/migrations/diesel/postgres/migrations/2021-09-27-094150_receipt_store_service_id/up.sql
+++ b/libsawtooth/src/migrations/diesel/postgres/migrations/2021-09-27-094150_receipt_store_service_id/up.sql
@@ -1,0 +1,21 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Add a `service_id` column and modify idx to drop unique constraint
+ALTER TABLE transaction_receipt
+DROP CONSTRAINT transaction_receipt_idx_key;
+
+ALTER TABLE transaction_receipt
+ADD COLUMN service_id TEXT;

--- a/libsawtooth/src/migrations/diesel/sqlite/migrations/2021-09-27-094150_receipt_store_service_id/down.sql
+++ b/libsawtooth/src/migrations/diesel/sqlite/migrations/2021-09-27-094150_receipt_store_service_id/down.sql
@@ -1,0 +1,25 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Recreate the table with the unique constraint
+CREATE TABLE IF NOT EXISTS transaction_receipt_copy (
+    transaction_id              TEXT PRIMARY KEY,
+    idx                         BIGINT NOT NULL UNIQUE
+);
+
+INSERT INTO transaction_receipt_copy(transaction_id, idx)
+    SELECT transaction_id, idx FROM transaction_receipt;
+DROP TABLE transaction_receipt;
+ALTER TABLE transaction_receipt_copy RENAME TO transaction_receipt;

--- a/libsawtooth/src/migrations/diesel/sqlite/migrations/2021-09-27-094150_receipt_store_service_id/up.sql
+++ b/libsawtooth/src/migrations/diesel/sqlite/migrations/2021-09-27-094150_receipt_store_service_id/up.sql
@@ -1,0 +1,26 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+-- Modify idx to drop uniqueness constraint and add a `service_id` column
+CREATE TABLE IF NOT EXISTS transaction_receipt_copy (
+    transaction_id              TEXT PRIMARY KEY,
+    idx                         BIGINT NOT NULL,
+    service_id                  TEXT
+);
+
+INSERT INTO transaction_receipt_copy(transaction_id, idx)
+    SELECT transaction_id, idx FROM transaction_receipt;
+DROP TABLE transaction_receipt;
+ALTER TABLE transaction_receipt_copy RENAME TO transaction_receipt;

--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -44,6 +44,7 @@ use operations::ReceiptStoreOperations;
 /// A database-backed ReceiptStore, powered by [`Diesel`](https://crates.io/crates/diesel).
 pub struct DieselReceiptStore<C: diesel::Connection + 'static> {
     connection_pool: Pool<ConnectionManager<C>>,
+    service_id: Option<String>,
 }
 
 impl<C: diesel::Connection> DieselReceiptStore<C> {
@@ -52,8 +53,11 @@ impl<C: diesel::Connection> DieselReceiptStore<C> {
     /// # Arguments
     ///
     ///  * `connection_pool`: connection pool for the database
-    pub fn new(connection_pool: Pool<ConnectionManager<C>>) -> Self {
-        DieselReceiptStore { connection_pool }
+    pub fn new(connection_pool: Pool<ConnectionManager<C>>, service_id: Option<String>) -> Self {
+        DieselReceiptStore {
+            connection_pool,
+            service_id,
+        }
     }
 }
 
@@ -62,6 +66,7 @@ impl Clone for DieselReceiptStore<diesel::sqlite::SqliteConnection> {
     fn clone(&self) -> Self {
         Self {
             connection_pool: self.connection_pool.clone(),
+            service_id: self.service_id.clone(),
         }
     }
 }
@@ -71,6 +76,7 @@ impl Clone for DieselReceiptStore<diesel::pg::PgConnection> {
     fn clone(&self) -> Self {
         Self {
             connection_pool: self.connection_pool.clone(),
+            service_id: self.service_id.clone(),
         }
     }
 }
@@ -192,7 +198,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -226,7 +233,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -306,7 +314,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -382,7 +391,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -431,7 +441,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -492,7 +503,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -554,7 +566,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -603,7 +616,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts(10);
 
@@ -655,7 +669,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let mut receipts = Vec::new();
 
@@ -756,7 +771,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let mut receipts = Vec::new();
 
@@ -828,7 +844,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let mut receipts = Vec::new();
 
@@ -903,7 +920,8 @@ pub mod tests {
         let test_result = std::panic::catch_unwind(|| {
             let pool = create_connection_pool_and_migrate();
 
-            let receipt_store = DieselReceiptStore::new(pool);
+            let receipt_store =
+                DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
             let txn_receipts = create_txn_receipts_mixed_results(10);
 
@@ -983,7 +1001,7 @@ pub mod tests {
     fn test_sqlite_list_receipts_order() {
         let pool = create_connection_pool_and_migrate();
 
-        let receipt_store = DieselReceiptStore::new(pool);
+        let receipt_store = DieselReceiptStore::new(pool, Some("ABCDE-12345::AAaa".to_string()));
 
         let txn_receipts = create_txn_receipts(20);
 

--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -87,41 +87,47 @@ impl ReceiptStore for DieselReceiptStore<diesel::sqlite::SqliteConnection> {
         &self,
         id: String,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).get_txn_receipt_by_id(&id)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .get_txn_receipt_by_id(&id)
     }
 
     fn get_txn_receipt_by_index(
         &self,
         index: u64,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).get_txn_receipt_by_index(index)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .get_txn_receipt_by_index(index)
     }
 
     fn add_txn_receipts(&self, receipts: Vec<TransactionReceipt>) -> Result<(), ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).add_txn_receipts(receipts)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .add_txn_receipts(receipts)
     }
 
     fn remove_txn_receipt_by_id(
         &self,
         id: String,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).remove_txn_receipt_by_id(id)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .remove_txn_receipt_by_id(id)
     }
 
     fn remove_txn_receipt_by_index(
         &self,
         index: u64,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
             .remove_txn_receipt_by_index(index)
     }
 
     fn count_txn_receipts(&self) -> Result<u64, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).count_txn_receipts()
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .count_txn_receipts()
     }
 
     fn list_receipts_since(&self, id: Option<String>) -> Result<ReceiptIter, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).list_receipts_since(id)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .list_receipts_since(id)
     }
 }
 
@@ -131,41 +137,47 @@ impl ReceiptStore for DieselReceiptStore<diesel::pg::PgConnection> {
         &self,
         id: String,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).get_txn_receipt_by_id(&id)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .get_txn_receipt_by_id(&id)
     }
 
     fn get_txn_receipt_by_index(
         &self,
         index: u64,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).get_txn_receipt_by_index(index)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .get_txn_receipt_by_index(index)
     }
 
     fn add_txn_receipts(&self, receipts: Vec<TransactionReceipt>) -> Result<(), ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).add_txn_receipts(receipts)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .add_txn_receipts(receipts)
     }
 
     fn remove_txn_receipt_by_id(
         &self,
         id: String,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).remove_txn_receipt_by_id(id)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .remove_txn_receipt_by_id(id)
     }
 
     fn remove_txn_receipt_by_index(
         &self,
         index: u64,
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
             .remove_txn_receipt_by_index(index)
     }
 
     fn count_txn_receipts(&self) -> Result<u64, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).count_txn_receipts()
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .count_txn_receipts()
     }
 
     fn list_receipts_since(&self, id: Option<String>) -> Result<ReceiptIter, ReceiptStoreError> {
-        ReceiptStoreOperations::new(&*self.connection_pool.get()?).list_receipts_since(id)
+        ReceiptStoreOperations::new(&*self.connection_pool.get()?, self.service_id.clone())
+            .list_receipts_since(id)
     }
 }
 

--- a/libsawtooth/src/receipt/store/diesel/models.rs
+++ b/libsawtooth/src/receipt/store/diesel/models.rs
@@ -43,6 +43,7 @@ use crate::receipt::store::error::ReceiptStoreError;
 pub struct TransactionReceiptModel {
     pub transaction_id: String,
     pub idx: i64,
+    pub service_id: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Associations, Identifiable, Insertable, Queryable, QueryableByName)]

--- a/libsawtooth/src/receipt/store/diesel/operations/add_txn_receipts.rs
+++ b/libsawtooth/src/receipt/store/diesel/operations/add_txn_receipts.rs
@@ -55,7 +55,11 @@ impl<'a> ReceiptStoreAddTxnReceiptsOperation
 {
     fn add_txn_receipts(&self, receipts: Vec<TransactionReceipt>) -> Result<(), ReceiptStoreError> {
         self.conn.transaction::<(), _, _>(|| {
-            let index: i64 = match transaction_receipt::table
+            let mut query = transaction_receipt::table.into_boxed();
+            if let Some(service_id) = &self.service_id {
+                query = query.filter(transaction_receipt::service_id.eq(service_id));
+            };
+            let index: i64 = match query
                 .order(transaction_receipt::idx.desc())
                 .first::<TransactionReceiptModel>(self.conn)
                 .optional()?
@@ -71,6 +75,7 @@ impl<'a> ReceiptStoreAddTxnReceiptsOperation
                 let transaction_receipt_model = TransactionReceiptModel {
                     transaction_id: id.to_string(),
                     idx: index + i,
+                    service_id: self.service_id.clone(),
                 };
                 insert_into(transaction_receipt::table)
                     .values(transaction_receipt_model)
@@ -185,7 +190,11 @@ impl<'a> ReceiptStoreAddTxnReceiptsOperation
 {
     fn add_txn_receipts(&self, receipts: Vec<TransactionReceipt>) -> Result<(), ReceiptStoreError> {
         self.conn.transaction::<(), _, _>(|| {
-            let last_index: i64 = match transaction_receipt::table
+            let mut query = transaction_receipt::table.into_boxed();
+            if let Some(service_id) = &self.service_id {
+                query = query.filter(transaction_receipt::service_id.eq(service_id));
+            };
+            let last_index: i64 = match query
                 .order(transaction_receipt::idx.desc())
                 .first::<TransactionReceiptModel>(self.conn)
                 .optional()?
@@ -201,6 +210,7 @@ impl<'a> ReceiptStoreAddTxnReceiptsOperation
                 let transaction_receipt_model = TransactionReceiptModel {
                     transaction_id: id.to_string(),
                     idx: last_index + i,
+                    service_id: self.service_id.clone(),
                 };
                 insert_into(transaction_receipt::table)
                     .values(transaction_receipt_model)

--- a/libsawtooth/src/receipt/store/diesel/operations/get_txn_receipt_by_id.rs
+++ b/libsawtooth/src/receipt/store/diesel/operations/get_txn_receipt_by_id.rs
@@ -67,7 +67,11 @@ where
     ) -> Result<Option<TransactionReceipt>, ReceiptStoreError> {
         self.conn
             .transaction::<Option<TransactionReceipt>, _, _>(|| {
-                let txn_receipt: TransactionReceiptModel = match transaction_receipt::table
+                let mut query = transaction_receipt::table.into_boxed();
+                if let Some(service_id) = &self.service_id {
+                    query = query.filter(transaction_receipt::service_id.eq(service_id));
+                };
+                let txn_receipt: TransactionReceiptModel = match query
                     .select(transaction_receipt::all_columns)
                     .filter(transaction_receipt::transaction_id.eq(id.to_string()))
                     .first::<TransactionReceiptModel>(self.conn)

--- a/libsawtooth/src/receipt/store/diesel/operations/get_txn_receipt_by_index.rs
+++ b/libsawtooth/src/receipt/store/diesel/operations/get_txn_receipt_by_index.rs
@@ -72,7 +72,7 @@ where
                     Some(receipt) => receipt,
                     None => return Ok(None),
                 };
-                ReceiptStoreOperations::new(self.conn)
+                ReceiptStoreOperations::new(self.conn, self.service_id.clone())
                     .get_txn_receipt_by_id(&txn_receipt.transaction_id)
             })
     }

--- a/libsawtooth/src/receipt/store/diesel/operations/get_txn_receipt_by_index.rs
+++ b/libsawtooth/src/receipt/store/diesel/operations/get_txn_receipt_by_index.rs
@@ -63,7 +63,11 @@ where
                         "Unable to convert index into i64".to_string(),
                     ))
                 })?;
-                let txn_receipt: TransactionReceiptModel = match transaction_receipt::table
+                let mut query = transaction_receipt::table.into_boxed();
+                if let Some(service_id) = &self.service_id {
+                    query = query.filter(transaction_receipt::service_id.eq(service_id));
+                };
+                let txn_receipt: TransactionReceiptModel = match query
                     .select(transaction_receipt::all_columns)
                     .filter(transaction_receipt::idx.eq(index))
                     .first::<TransactionReceiptModel>(self.conn)

--- a/libsawtooth/src/receipt/store/diesel/operations/list_receipts_since.rs
+++ b/libsawtooth/src/receipt/store/diesel/operations/list_receipts_since.rs
@@ -59,12 +59,16 @@ where
         self.conn.transaction::<ReceiptIter, _, _>(|| {
             // Collect the `TransactionReceiptModels` of all transaction receipts
             // that are to be listed
+            let mut query = transaction_receipt::table.into_boxed();
+            if let Some(service_id) = &self.service_id {
+                query = query.filter(transaction_receipt::service_id.eq(service_id));
+            };
             let transaction_receipt_models: Vec<TransactionReceiptModel> = match id {
-                Some(id) => transaction_receipt::table
+                Some(id) => query
                     .filter(transaction_receipt::transaction_id.gt(id))
                     .select(transaction_receipt::all_columns)
                     .load(self.conn)?,
-                None => transaction_receipt::table
+                None => query
                     .select(transaction_receipt::all_columns)
                     .load(self.conn)?,
             };

--- a/libsawtooth/src/receipt/store/diesel/operations/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/operations/mod.rs
@@ -27,10 +27,11 @@ pub(super) mod remove_txn_receipt_by_index;
 
 pub struct ReceiptStoreOperations<'a, C> {
     conn: &'a C,
+    service_id: Option<String>,
 }
 
 impl<'a, C: diesel::Connection> ReceiptStoreOperations<'a, C> {
-    pub fn new(conn: &'a C) -> Self {
-        ReceiptStoreOperations { conn }
+    pub fn new(conn: &'a C, service_id: Option<String>) -> Self {
+        ReceiptStoreOperations { conn, service_id }
     }
 }

--- a/libsawtooth/src/receipt/store/diesel/schema.rs
+++ b/libsawtooth/src/receipt/store/diesel/schema.rs
@@ -19,6 +19,7 @@ table! {
     transaction_receipt (transaction_id) {
         transaction_id -> Text,
         idx -> Int8,
+        service_id -> Nullable<Text>,
     }
 }
 


### PR DESCRIPTION
This PR adds a `service_id` to the diesel implementation of receipt store. The `service_id` scopes the store to a specific instance of a receipt store. The index field is also updated to longer have a unique constraint, this is because with the addition of the `service_id` index only needs to be unique for a given `service_id`.