### PR TITLE
Fix type for state_change_type for postgres

### DIFF
--- a/libsawtooth/src/migrations/diesel/postgres/migrations/2021-11-18-202559_fix_state_change_type/down.sql
+++ b/libsawtooth/src/migrations/diesel/postgres/migrations/2021-11-18-202559_fix_state_change_type/down.sql
@@ -1,0 +1,17 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE valid_transaction_result_state_change
+ALTER COLUMN state_change_type TYPE INTEGER;

--- a/libsawtooth/src/migrations/diesel/postgres/migrations/2021-11-18-202559_fix_state_change_type/up.sql
+++ b/libsawtooth/src/migrations/diesel/postgres/migrations/2021-11-18-202559_fix_state_change_type/up.sql
@@ -1,0 +1,17 @@
+--- Copyright 2018-2021 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE valid_transaction_result_state_change
+ALTER COLUMN state_change_type TYPE SMALLINT;


### PR DESCRIPTION
For postgres, there is a difference between Integer and
SmallInt. Before the state change types were being set to Integer
but the rest of the code expected them to be SmallInt.

Issues was found while testing Splinter with PostgreSQL

```
[2021-11-18 11:45:43.282] T[actix-rt:worker:2] DEBUG [splinter::rest_api::actix_web_1::websocket] Starting Event Websocket
thread 'actix-rt:worker:0' panicked at 'Received more than 2 bytes decoding i16. Was an Integer expression accidentally identified as SmallInt?', /Users/agunde/.cargo/registry/src/github.com-1ecc6299db9ec823/diesel-1.4.7/src/type_impls/integers.rs:13:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
``` 