### PR TITLE
Replace openssl with sha2

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -34,10 +34,10 @@ hex = "0.4"
 log = "0.4"
 lmdb-zero = { version = "0.4", optional = true }
 metrics = { version = "0.12", features = ["std"], optional = true }
-openssl = { version = "0.10", optional = true }
 protobuf = "2.23"
 reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
+sha2 = { version = "0.9", optional = true }
 transact = "0.3"
 uluru = { version = "0.4", optional = true }
 
@@ -79,7 +79,7 @@ validator-internals = [
   "cbor-codec",
   "lmdb-zero",
   "metrics",
-  "openssl",
+  "sha2",
   "uluru",
 ]
 

--- a/libsawtooth/src/hashlib.rs
+++ b/libsawtooth/src/hashlib.rs
@@ -15,22 +15,24 @@
  * ------------------------------------------------------------------------------
  */
 
+use sha2::{Digest, Sha256, Sha512};
+
 pub fn sha256_digest_str(item: &str) -> String {
-    hex::encode(openssl::sha::sha256(item.as_bytes()))
+    hex::encode(sha256_digest_strs(&[item.to_string()]))
 }
 
 pub fn sha256_digest_strs(strs: &[String]) -> Vec<u8> {
-    let mut hasher = openssl::sha::Sha256::new();
+    let mut hasher = Sha256::new();
     for item in strs {
         hasher.update(item.as_bytes());
     }
     let mut bytes = Vec::new();
-    bytes.extend(hasher.finish().iter());
+    bytes.extend(hasher.finalize().into_iter());
     bytes
 }
 
 pub fn sha512_digest_bytes(item: &[u8]) -> Vec<u8> {
-    let mut bytes: Vec<u8> = Vec::new();
-    bytes.extend(openssl::sha::sha512(item).iter());
-    bytes
+    let mut hasher = Sha512::new();
+    hasher.update(item);
+    hasher.finalize().to_vec()
 }


### PR DESCRIPTION
This change replaces the `openssl` dependency with the `sha2` dependency. 

OpenSSL was only be used for SHA hashes, which can be provided by the lighter-weight, pure-rust `sha2` library.
