### PR TITLE
Add a missing guard on client::rest module

### DIFF
--- a/libsawtooth/src/client/mod.rs
+++ b/libsawtooth/src/client/mod.rs
@@ -15,6 +15,7 @@
 //! A trait for implementing a sawtooth client.
 
 mod error;
+#[cfg(feature = "client-rest")]
 pub mod rest;
 
 pub use error::SawtoothClientError;


### PR DESCRIPTION
The client::rest module should only be enabled if the client-rest
feature has been enabled. This fixes a bug where the "client" feature
could not be compiled in isolation.
