### PR TITLE
Fix feature guard around extern diesel

### DIFF
--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #[macro_use]
-#[cfg(feature = "diesel")]
+#[cfg(all(feature = "diesel", feature = "transaction-receipt-store"))]
 extern crate diesel;
 #[macro_use]
 #[cfg(feature = "diesel")]


### PR DESCRIPTION
Only the transaction-receipt-store module uses diesel macros; this
change prevents compilation warnings.