### PR TITLE
Add missing guard on log

### DIFF
--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -21,6 +21,7 @@ extern crate diesel_migrations;
 #[cfg(any(
     feature = "validator-internals",
     feature = "client-rest",
+    all(feature = "transaction-receipt-store", feature = "lmdb"),
     feature = "postgres",
     feature = "sqlite",
 ))]


### PR DESCRIPTION
This change adds a missing guard to the `extern crate log` to include the `"lmdb"` feature. Otherwise, the feature combination of `"transaction-receipt-store"` and `"lmdb"` will not compile.  This would occur in instances where only LMDB is in use.
