### PR TITLE
Add a `clone_box` method to `ReceiptStore`

### DIFF
--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -161,6 +161,10 @@ impl ReceiptStore for DieselReceiptStore<diesel::sqlite::SqliteConnection> {
             ReceiptStoreOperations::new(conn, self.service_id.as_deref()).list_receipts_since(id)
         })
     }
+
+    fn clone_box(&self) -> Box<dyn ReceiptStore> {
+        Box::new(self.clone())
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -220,6 +224,10 @@ impl ReceiptStore for DieselReceiptStore<diesel::pg::PgConnection> {
         self.connection_pool.execute_read(|conn| {
             ReceiptStoreOperations::new(conn, self.service_id.as_deref()).list_receipts_since(id)
         })
+    }
+
+    fn clone_box(&self) -> Box<dyn ReceiptStore> {
+        Box::new(self.clone())
     }
 }
 

--- a/libsawtooth/src/receipt/store/lmdb.rs
+++ b/libsawtooth/src/receipt/store/lmdb.rs
@@ -504,6 +504,13 @@ impl ReceiptStore for LmdbReceiptStore {
         };
         Ok(Box::new(iter))
     }
+
+    fn clone_box(&self) -> Box<dyn ReceiptStore> {
+        Box::new(Self {
+            databases: self.databases.clone(),
+            current_db: self.current_db.clone(),
+        })
+    }
 }
 
 /// A range that defines the start and end bounds for a range iterator on an `LmdbReceiptStore`.

--- a/libsawtooth/src/receipt/store/mod.rs
+++ b/libsawtooth/src/receipt/store/mod.rs
@@ -87,6 +87,8 @@ pub trait ReceiptStore: Sync + Send {
     /// * `id` - The transaction ID of the receipt preceding the receipts to be
     ///          listed, if no id is provided all receipts are listed
     fn list_receipts_since(&self, id: Option<String>) -> Result<ReceiptIter, ReceiptStoreError>;
+
+    fn clone_box(&self) -> Box<dyn ReceiptStore>;
 }
 
 /// Return type of the receipt store's `list_receipts_since` method.


### PR DESCRIPTION
Add a `clone_box` method to the trait and each of the implementations of
ReceiptStore.

Signed-off-by: Isabel Tomb <tomb@bitwise.io>