### PR TITLE
Update receipt store function to filter on `service_id`

### DIFF
--- a/libsawtooth/src/receipt/store/diesel/mod.rs
+++ b/libsawtooth/src/receipt/store/diesel/mod.rs
@@ -1163,6 +1163,18 @@ pub mod tests {
                 .list_receipts_since(None)
                 .expect("failed to list all transaction receipts from receipt store 1");
 
+            let num_receipts_receipt_store_1 = receipt_store_1
+                .count_txn_receipts()
+                .expect("failed to count transaction receipts");
+
+            assert_eq!(num_receipts_receipt_store_1, 5);
+
+            let num_receipts_receipt_store_2 = receipt_store_2
+                .count_txn_receipts()
+                .expect("failed to count transaction receipts");
+
+            assert_eq!(num_receipts_receipt_store_2, 5);
+
             let mut total = 0;
             for (i, receipt) in vec![0, 1, 2, 6, 7]
                 .into_iter()

--- a/libsawtooth/src/receipt/store/diesel/operations/count_txn_receipts.rs
+++ b/libsawtooth/src/receipt/store/diesel/operations/count_txn_receipts.rs
@@ -40,7 +40,11 @@ where
 {
     fn count_txn_receipts(&self) -> Result<u64, ReceiptStoreError> {
         self.conn.transaction::<u64, _, _>(|| {
-            let count = transaction_receipt::table
+            let mut query = transaction_receipt::table.into_boxed();
+            if let Some(service_id) = &self.service_id {
+                query = query.filter(transaction_receipt::service_id.eq(service_id));
+            };
+            let count = query
                 .select(transaction_receipt::all_columns)
                 .select(count_star())
                 .first::<i64>(self.conn)?;


### PR DESCRIPTION
- Update the `count_txn_receipts` function to filter on the optional service ID when one is set.
- Update the multiple service ID receipt store test to call `count_txn_receipts` and ensure it returns the correct number of receipts.