### PR TITLE
Add a database index on transaction_receipt

### DIFF
--- a/libsawtooth/src/migrations/diesel/postgres/migrations/2022-01-27-103000_add_transaction_receipt_index/down.sql
+++ b/libsawtooth/src/migrations/diesel/postgres/migrations/2022-01-27-103000_add_transaction_receipt_index/down.sql
@@ -1,0 +1,16 @@
+--- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP INDEX idx_transaction_receipt_idx_service_id;

--- a/libsawtooth/src/migrations/diesel/postgres/migrations/2022-01-27-103000_add_transaction_receipt_index/up.sql
+++ b/libsawtooth/src/migrations/diesel/postgres/migrations/2022-01-27-103000_add_transaction_receipt_index/up.sql
@@ -1,0 +1,17 @@
+--- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE INDEX idx_transaction_receipt_idx_service_id
+    ON transaction_receipt(idx, service_id);

--- a/libsawtooth/src/migrations/diesel/sqlite/migrations/2022-01-27-103000_add_transaction_receipt_index/down.sql
+++ b/libsawtooth/src/migrations/diesel/sqlite/migrations/2022-01-27-103000_add_transaction_receipt_index/down.sql
@@ -1,0 +1,16 @@
+--- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+DROP INDEX idx_transaction_receipt_idx_service_id;

--- a/libsawtooth/src/migrations/diesel/sqlite/migrations/2022-01-27-103000_add_transaction_receipt_index/up.sql
+++ b/libsawtooth/src/migrations/diesel/sqlite/migrations/2022-01-27-103000_add_transaction_receipt_index/up.sql
@@ -1,0 +1,17 @@
+--- Copyright 2018-2022 Cargill Incorporated
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- -----------------------------------------------------------------------------
+
+CREATE INDEX idx_transaction_receipt_idx_service_id
+    ON transaction_receipt(idx, service_id);


### PR DESCRIPTION
This change adds an index on the "idx" and "service_id" columns of the transaction_receipt table.  These columns are frequently used for queries.

Use of these columns  has been identified as the source of a performance issue with the query to find the latest `idx` value for a given service id (found at the start of the `AddTxnReceiptsOperation`).