### PR TITLE
Update and patch transact version to 0.5

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -38,7 +38,7 @@ protobuf = "2.23"
 reqwest = { version = "0.11", optional = true, features = ["blocking", "json"] }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 sha2 = { version = "0.9", optional = true }
-transact = "0.4"
+transact = "0.5"
 uluru = { version = "3", optional = true }
 
 [dev-dependencies]
@@ -91,3 +91,6 @@ features = [
     "stable",
     "experimental"
 ]
+
+[patch.crates-io]
+transact = { git = "https://github.com/hyperledger/transact" }


### PR DESCRIPTION
This commit updates the transact version to be 0.5.
This version is not yet released but will be the
version used in the 0.8 (current main) release of
libsawtooth. As such, a patch is added into the Cargo.toml
to have the transact version be pulled in from the main
branch of transact on github.

This is required before https://github.com/Cargill/splinter/pull/1801 will work