### PR TITLE
Add new traits and structs for the new Publisher design

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -69,6 +69,7 @@ experimental = [
     "client",
     "client-rest",
     "pending-batch-queue",
+    "publisher",
     "validator-internals",
 ]
 
@@ -80,6 +81,7 @@ client-rest = ["base64", "client", "log", "reqwest", "serde"]
 lmdb = ["lmdb-zero", "log"]
 pending-batch-queue = ["validator-internals"]
 postgres = ["diesel/postgres", "diesel_migrations", "log", "store"]
+publisher = ["artifact-creator"]
 sqlite = ["diesel/sqlite", "diesel_migrations", "log", "store"]
 store = []
 transaction-receipt-store = []

--- a/libsawtooth/src/error/internal.rs
+++ b/libsawtooth/src/error/internal.rs
@@ -17,6 +17,9 @@
 use std::error;
 use std::fmt;
 
+#[cfg(feature = "publisher")]
+use log::debug;
+
 struct Source {
     prefix: Option<String>,
     source: Box<dyn error::Error>,
@@ -125,6 +128,19 @@ impl InternalError {
             message: Some(message),
             source: None,
         }
+    }
+
+    /// Reduces the `InternalError` to the display string
+    ///
+    /// If the error includes a source, the debug format will be logged to provide
+    /// information that may be lost on the conversion.
+    #[cfg(feature = "publisher")]
+    pub fn reduce_to_string(self) -> String {
+        if self.source.is_some() {
+            debug!("{:?}", self);
+        }
+
+        self.to_string()
     }
 }
 

--- a/libsawtooth/src/lib.rs
+++ b/libsawtooth/src/lib.rs
@@ -40,6 +40,8 @@ pub mod migrations;
 pub mod permissions;
 pub mod protocol;
 pub mod protos;
+#[cfg(feature = "publisher")]
+pub mod publisher;
 #[cfg(any(feature = "transaction-receipt-store", feature = "validator-internals"))]
 pub mod receipt;
 #[cfg(feature = "validator-internals")]

--- a/libsawtooth/src/publisher/batch.rs
+++ b/libsawtooth/src/publisher/batch.rs
@@ -15,8 +15,6 @@
  * ------------------------------------------------------------------------------
  */
 
-//! Contains traits and struct required publishing new artifacts
+//! A trait that represents a `Batch`
 
-mod batch;
-
-pub use batch::Batch;
+pub trait Batch: Send {}

--- a/libsawtooth/src/publisher/batch_verifier.rs
+++ b/libsawtooth/src/publisher/batch_verifier.rs
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Contains traits related to `Batch` verification
+
+use crate::error::InternalError;
+
+use super::Batch;
+use super::PublishingContext;
+
+/// Result of executing a batch.
+pub trait BatchExecutionResult: Send {}
+
+/// A Factory to create `BatchVerifier` instances
+pub trait BatchVerifierFactory {
+    type Batch: Batch;
+    type Context: PublishingContext;
+    type ExecutionResult: BatchExecutionResult;
+
+    // allow type complexity here because of the use of associated types
+    #[allow(clippy::type_complexity)]
+    /// Start execution of batches in relation to a specific context by
+    /// returning a `BatchVerifier`
+    fn start(
+        &mut self,
+        context: Self::Context,
+    ) -> Result<
+        Box<
+            dyn BatchVerifier<
+                Batch = Self::Batch,
+                Context = Self::Context,
+                ExecutionResult = Self::ExecutionResult,
+            >,
+        >,
+        InternalError,
+    >;
+}
+
+/// Verify the contents of a `Batch` and its transactions
+pub trait BatchVerifier: Send {
+    type Batch: Batch;
+    type Context: PublishingContext;
+    type ExecutionResult: BatchExecutionResult;
+
+    /// Add a new batch to the verifier
+    fn add_batch(&mut self, batch: Self::Batch) -> Result<(), InternalError>;
+
+    /// Finalize the verification of the batches, returning the execution results of batches
+    /// that have completed execution.
+    fn finalize(&mut self) -> Result<Vec<Self::ExecutionResult>, InternalError>;
+
+    /// Cancel exeuction of batches, discarding all excution results
+    fn cancel(&mut self) -> Result<(), InternalError>;
+}

--- a/libsawtooth/src/publisher/context.rs
+++ b/libsawtooth/src/publisher/context.rs
@@ -15,10 +15,7 @@
  * ------------------------------------------------------------------------------
  */
 
-//! Contains traits and struct required publishing new artifacts
+//! Contains the trait for the context used by the publisher
 
-mod batch;
-mod context;
-
-pub use batch::Batch;
-pub use context::PublishingContext;
+/// The context used by the publisher
+pub trait PublishingContext: Send {}

--- a/libsawtooth/src/publisher/factory.rs
+++ b/libsawtooth/src/publisher/factory.rs
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Conatains the struct for starting publishing of a new artifact
+
+use std::sync::mpsc::channel;
+use std::thread;
+
+use crate::artifact::{Artifact, ArtifactCreator, ArtifactCreatorFactory};
+use crate::error::InternalError;
+
+use super::message::PublishMessage;
+use super::{
+    Batch, BatchExecutionResult, BatchVerifierFactory, PendingBatches, PublishHandle,
+    PublishingContext,
+};
+
+/// Factory to start publishing a new artificat
+///
+/// The `PublishFactory` starts up the exeuction and verification of batches by
+/// spinning up a thread and returning a `PublishHandle` that can be used to
+/// control the thread execution.
+///
+// allow type complexity here because of the use of associated types
+#[allow(clippy::type_complexity)]
+pub struct PublishFactory<B, C, R, I>
+where
+    B: 'static + Batch + Clone,
+    C: 'static + PublishingContext + Clone,
+    R: 'static + Artifact,
+    I: 'static + BatchExecutionResult,
+{
+    artifact_creator_factory: Box<
+        dyn ArtifactCreatorFactory<
+            ArtifactCreator = Box<dyn ArtifactCreator<Context = C, Input = Vec<I>, Artifact = R>>,
+        >,
+    >,
+    batch_verifier_factory:
+        Box<dyn BatchVerifierFactory<Batch = B, Context = C, ExecutionResult = I>>,
+}
+
+/// Create a new `PublishFactory`
+///
+/// Arguments
+///
+/// * `artifact_creator_factory` - a factory for creating a new artifact creator for a new
+///    publishing thread
+/// * `batch_verifier_factory` - a factory for creating a new batch verifier for a new publishing
+///    thread
+///
+// allow type complexity here because of the use of associated types
+#[allow(clippy::type_complexity)]
+impl<B, C, R, I> PublishFactory<B, C, R, I>
+where
+    B: 'static + Batch + Clone,
+    C: 'static + PublishingContext + Clone,
+    R: 'static + Artifact,
+    I: 'static + BatchExecutionResult,
+{
+    pub fn new(
+        artifact_creator_factory: Box<
+            dyn ArtifactCreatorFactory<
+                ArtifactCreator = Box<
+                    dyn ArtifactCreator<Context = C, Input = Vec<I>, Artifact = R>,
+                >,
+            >,
+        >,
+        batch_verifier_factory: Box<
+            dyn BatchVerifierFactory<Batch = B, Context = C, ExecutionResult = I>,
+        >,
+    ) -> Self {
+        Self {
+            artifact_creator_factory,
+            batch_verifier_factory,
+        }
+    }
+}
+
+impl<B, C, R, I> PublishFactory<B, C, R, I>
+where
+    B: 'static + Batch + Clone,
+    C: 'static + PublishingContext + Clone,
+    R: 'static + Artifact,
+    I: 'static + BatchExecutionResult,
+{
+    /// Start building the next `Artifact`
+    ///
+    /// # Arguments
+    ///
+    /// * `context` - Implementation specific context for the publisher
+    /// * `batches` - An interator the returns the next batch to execute
+    ///
+    /// Returns a PublishHandle that can be used to finish or cancel the executing batch
+    ///
+    pub fn start(
+        &mut self,
+        mut context: C,
+        mut batches: Box<dyn PendingBatches<B>>,
+    ) -> Result<PublishHandle<R>, InternalError> {
+        let (sender, rc) = channel();
+        let mut verifier = self.batch_verifier_factory.start(context.clone())?;
+        let artifact_creator = self.artifact_creator_factory.new_creator()?;
+        let join_handle = thread::spawn(move || loop {
+            // drain the queue
+            while let Some(batch) = batches.next().map_err(|err| err.reduce_to_string())? {
+                verifier
+                    .add_batch(batch)
+                    .map_err(|err| err.reduce_to_string())?;
+            }
+
+            // Check to see if the batch result should be finished/canceled
+            match rc.recv() {
+                Ok(PublishMessage::Cancel) => {
+                    verifier.cancel().map_err(|err| err.reduce_to_string())?;
+                    return Ok(None);
+                }
+                Ok(PublishMessage::Finish) => {
+                    let results = verifier.finalize().map_err(|err| err.reduce_to_string())?;
+
+                    return Ok(Some(
+                        artifact_creator
+                            .create(&mut context, results)
+                            .map_err(|err| err.reduce_to_string())?,
+                    ));
+                }
+                Ok(PublishMessage::Dropped) => {
+                    return Ok(None);
+                }
+                Ok(PublishMessage::Next) => {
+                    while let Some(batch) = batches.next().map_err(|err| err.reduce_to_string())? {
+                        verifier
+                            .add_batch(batch)
+                            .map_err(|err| err.reduce_to_string())?;
+                    }
+                }
+                Err(err) => {
+                    return Err(InternalError::from_source(Box::new(err)).reduce_to_string());
+                }
+            };
+        });
+
+        Ok(PublishHandle::new(sender, join_handle))
+    }
+}

--- a/libsawtooth/src/publisher/handler.rs
+++ b/libsawtooth/src/publisher/handler.rs
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Contains the `PublishHandle` struct used for interating publishing thread
+
+use std::sync::mpsc::Sender;
+use std::thread;
+
+use log::error;
+
+use crate::artifact::Artifact;
+use crate::error::InternalError;
+
+use super::message::PublishMessage;
+
+/// Handler for interating with a publishing thread
+pub struct PublishHandle<R>
+where
+    R: Artifact,
+{
+    sender: Option<Sender<PublishMessage>>,
+    join_handle: Option<thread::JoinHandle<Result<Option<R>, String>>>,
+}
+
+impl<R> PublishHandle<R>
+where
+    R: Artifact,
+{
+    /// Create a new `PublishHandle`
+    ///
+    /// Arguments
+    ///
+    /// * `sender` - The `Sender` for seting updates to the publishing thread
+    /// * `join_handle` - The `JoinHandle` to the publishing thread, used to get the published
+    ///    `Artifact`
+    pub fn new(
+        sender: Sender<PublishMessage>,
+        join_handle: thread::JoinHandle<Result<Option<R>, String>>,
+    ) -> Self {
+        Self {
+            sender: Some(sender),
+            join_handle: Some(join_handle),
+        }
+    }
+
+    /// Finish constructing the block, returning a result that contains the bytes that consensus
+    /// must agree upon and a list of TransactionReceipts. Any batches that are not finished
+    /// processing, will be returned to the pending state.
+    pub fn finish(mut self) -> Result<R, InternalError> {
+        if let Some(sender) = self.sender.take() {
+            sender
+                .send(PublishMessage::Finish)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            match self
+                .join_handle
+                .take()
+                .ok_or_else(|| InternalError::with_message("Missing join handle".into()))?
+                .join()
+                .map_err(|err| {
+                    InternalError::with_message(format!(
+                        "Unable to call join on join handle: {:?}",
+                        err
+                    ))
+                })? {
+                Ok(Some(result)) => Ok(result),
+                // no result returned
+                Ok(None) => Err(InternalError::with_message(
+                    "Publishing was finalized, should have received results".into(),
+                )),
+                Err(err) => Err(InternalError::with_message(err)),
+            }
+        } else {
+            // already called finish or cancel
+            Err(InternalError::with_message(
+                "Publishing has already been finished or canceled".into(),
+            ))
+        }
+    }
+
+    /// Cancel the currently building block, putting all batches back into a pending state
+    pub fn cancel(mut self) -> Result<(), InternalError> {
+        if let Some(sender) = self.sender.take() {
+            sender
+                .send(PublishMessage::Cancel)
+                .map_err(|err| InternalError::from_source(Box::new(err)))?;
+            match self
+                .join_handle
+                .take()
+                .ok_or_else(|| InternalError::with_message("Missing join handle".into()))?
+                .join()
+                .map_err(|err| {
+                    InternalError::with_message(format!(
+                        "Unable to call join on join handle: {:?}",
+                        err
+                    ))
+                })? {
+                // Did not expect any results
+                Ok(Some(_)) => Err(InternalError::with_message(
+                    "Publishing was cancel, should not have got results".into(),
+                )),
+                Ok(None) => Ok(()),
+                Err(err) => Err(InternalError::with_message(err)),
+            }
+        } else {
+            // already called finish or cancel
+            Err(InternalError::with_message(
+                "Publishing has already been finished or canceled".into(),
+            ))
+        }
+    }
+
+    /// Notify that there is a batch added to the pending queue
+    pub fn next_batch(&self) -> Result<(), InternalError> {
+        if let Some(sender) = &self.sender {
+            sender
+                .send(PublishMessage::Next)
+                .map_err(|err| InternalError::from_source(Box::new(err)))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<R> Drop for PublishHandle<R>
+where
+    R: Artifact,
+{
+    fn drop(&mut self) {
+        if let Some(sender) = self.sender.take() {
+            match sender.send(PublishMessage::Dropped) {
+                Ok(_) => (),
+                Err(_) => {
+                    error!("Unable to shutdown Publisher thread")
+                }
+            }
+        }
+    }
+}

--- a/libsawtooth/src/publisher/message.rs
+++ b/libsawtooth/src/publisher/message.rs
@@ -15,14 +15,11 @@
  * ------------------------------------------------------------------------------
  */
 
-//! Contains traits and struct required publishing new artifacts
+//! Contains the message used by the publisher
 
-mod batch;
-mod batch_verifier;
-mod context;
-mod message;
-
-pub use batch::Batch;
-pub use batch_verifier::{BatchExecutionResult, BatchVerifier, BatchVerifierFactory};
-pub use context::PublishingContext;
-
+pub enum PublishMessage {
+    Cancel,
+    Finish,
+    Next,
+    Dropped,
+}

--- a/libsawtooth/src/publisher/mod.rs
+++ b/libsawtooth/src/publisher/mod.rs
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2022 Cargill Incorporated
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------------------
+ */
+
+//! Contains traits and struct required publishing new artifacts

--- a/libsawtooth/src/publisher/mod.rs
+++ b/libsawtooth/src/publisher/mod.rs
@@ -18,7 +18,10 @@
 //! Contains traits and struct required publishing new artifacts
 
 mod batch;
+mod batch_verifier;
 mod context;
 
 pub use batch::Batch;
+pub use batch_verifier::{BatchExecutionResult, BatchVerifier, BatchVerifierFactory};
 pub use context::PublishingContext;
+

--- a/libsawtooth/src/publisher/mod.rs
+++ b/libsawtooth/src/publisher/mod.rs
@@ -31,3 +31,283 @@ pub use context::PublishingContext;
 pub use factory::PublishFactory;
 pub use handler::PublishHandle;
 pub use pending_batches::PendingBatches;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::{Arc, Mutex};
+
+    use crate::artifact::{Artifact, ArtifactCreator, ArtifactCreatorFactory};
+    use crate::error::InternalError;
+
+    /// Verify that the `PublisherFactory` and `PublishHandle` work as expected.
+    ///
+    /// 1. Create an `ArtifactCreatorFactory` and `BatchVerifierFactory` that uses the test
+    ///    implementation of the traits
+    /// 2. Create the `PublishFactory`
+    /// 3. Create a batch iterator with 1 batch and a genesis publishing context
+    /// 4. Start publishing thread, verify a publish handle is returned
+    /// 5. Use `PublishHandle` to notify thread of next batch and finish artifact
+    /// 6. Verify the correct artifact is returned and the context was updated
+    /// 7. Start a publishing thread with same context and new pending batches
+    /// 8. Cancel publishing and verify the context was not updated
+    /// 9. Start publishing with same context and new pending batches
+    /// 10. Verify a new artifact is returned and that the context was updated
+    #[test]
+    fn test_artifact_publishing() {
+        let artifact_creator_factory = Box::new(TestArtifactCreatorFactory {});
+        let batch_verifier_factory = Box::new(TestBatchVerifierFactory {});
+
+        let mut publish_factory: PublishFactory<
+            TestBatch,
+            Arc<Mutex<TestContext>>,
+            TestArtifact,
+            TestBatchExecutionResult,
+        > = PublishFactory::new(artifact_creator_factory, batch_verifier_factory);
+
+        let pending_batches = Box::new(BatchIter {
+            batches: vec![TestBatch {
+                value: "value_1".to_string(),
+            }],
+        });
+
+        let context = Arc::new(Mutex::new(TestContext {
+            current_block_height: 0,
+            current_state_value: "genesis".to_string(),
+        }));
+
+        // Start publishing for first batch
+        let publish_handle = publish_factory
+            .start(context.clone(), pending_batches)
+            .expect("Unable to start publishing thread");
+
+        publish_handle
+            .next_batch()
+            .expect("Unable to notify publisher thread of new batch");
+        // Finish the publishing of the artifact
+        let artifact = publish_handle
+            .finish()
+            .expect("Unable to finalize publishing thread");
+
+        assert_eq!(artifact.block_height, 1);
+        assert_eq!(artifact.current_value, "value_1".to_string());
+
+        let context_unlocked = context.lock().unwrap();
+        assert_eq!(context_unlocked.current_block_height, 1);
+        assert_eq!(context_unlocked.current_state_value, "value_1".to_string());
+
+        drop(context_unlocked);
+
+        // Start publishing for execution that will be canceled
+        let pending_batches = Box::new(BatchIter {
+            batches: vec![TestBatch {
+                value: "value_bad".to_string(),
+            }],
+        });
+
+        let publish_handle = publish_factory
+            .start(context.clone(), pending_batches)
+            .expect("Unable to start publishing thread");
+
+        publish_handle
+            .next_batch()
+            .expect("Unable to notify publisher thread of new batch");
+
+        // cancel publishing
+        publish_handle
+            .cancel()
+            .expect("Unable to finalize publishing thread");
+
+        // verify that the context was not updated
+        let context_unlocked = context.lock().unwrap();
+        assert_eq!(context_unlocked.current_block_height, 1);
+        assert_eq!(context_unlocked.current_state_value, "value_1".to_string());
+        drop(context_unlocked);
+
+        let pending_batches = Box::new(BatchIter {
+            batches: vec![TestBatch {
+                value: "value_2".to_string(),
+            }],
+        });
+
+        // start publishing a new artifact
+        let publish_handle = publish_factory
+            .start(context.clone(), pending_batches)
+            .expect("Unable to start publishing thread");
+
+        publish_handle
+            .next_batch()
+            .expect("Unable to notify publisher thread of new batch");
+
+        // Finalize the new artifact
+        let artifact = publish_handle
+            .finish()
+            .expect("Unable to finalize publishing thread");
+
+        // verify the correct artifact was returned and the context updated
+        assert_eq!(artifact.block_height, 2);
+        assert_eq!(artifact.current_value, "value_2".to_string());
+
+        let context_unlocked = context.lock().unwrap();
+        assert_eq!(context_unlocked.current_block_height, 2);
+        assert_eq!(context_unlocked.current_state_value, "value_2".to_string());
+    }
+
+    #[derive(Clone)]
+    struct TestBatch {
+        value: String,
+    }
+
+    impl Batch for TestBatch {}
+
+    #[derive(Clone)]
+    struct TestContext {
+        current_block_height: i32,
+        current_state_value: String,
+    }
+
+    impl PublishingContext for Arc<Mutex<TestContext>> {}
+
+    #[derive(Clone)]
+    struct TestArtifact {
+        block_height: i32,
+        current_value: String,
+    }
+
+    impl Artifact for TestArtifact {
+        type Identifier = i32;
+
+        /// Returns a reference to this artifact's identifier.
+        fn artifact_id(&self) -> &Self::Identifier {
+            &self.block_height
+        }
+    }
+
+    struct TestArtifactCreator {}
+
+    impl ArtifactCreator for TestArtifactCreator {
+        /// The context that contains extraneous information required to create the
+        /// `Artifact`.
+        type Context = Arc<Mutex<TestContext>>;
+        /// The type of input for the specific `Artifact`
+        type Input = Vec<TestBatchExecutionResult>;
+        /// The `Artifact` type
+        type Artifact = TestArtifact;
+
+        /// Creates a new `Artifact`
+        ///
+        /// Returns a an `Artifact` created from the context and input
+        fn create(
+            &self,
+            context: &mut Self::Context,
+            input: Self::Input,
+        ) -> Result<Self::Artifact, InternalError> {
+            let mut context = context.lock().unwrap();
+            context.current_block_height = context.current_block_height + 1;
+            context.current_state_value = input[0].value.to_string();
+            Ok(TestArtifact {
+                block_height: context.current_block_height,
+                current_value: input[0].value.to_string(),
+            })
+        }
+    }
+
+    struct TestArtifactCreatorFactory {}
+
+    impl ArtifactCreatorFactory for TestArtifactCreatorFactory {
+        /// The `ArtifactCreator` type
+        type ArtifactCreator = Box<
+            dyn ArtifactCreator<
+                Context = Arc<Mutex<TestContext>>,
+                Input = Vec<TestBatchExecutionResult>,
+                Artifact = TestArtifact,
+            >,
+        >;
+
+        /// Returns a new `ArtifactCreator`
+        fn new_creator(&self) -> Result<Self::ArtifactCreator, InternalError> {
+            Ok(Box::new(TestArtifactCreator {}))
+        }
+    }
+
+    struct TestBatchExecutionResult {
+        value: String,
+    }
+
+    impl BatchExecutionResult for TestBatchExecutionResult {}
+
+    struct TestBatchVerifier {
+        current_value: Option<String>,
+    }
+
+    impl BatchVerifier for TestBatchVerifier {
+        type Batch = TestBatch;
+        type Context = Arc<Mutex<TestContext>>;
+        type ExecutionResult = TestBatchExecutionResult;
+
+        /// Add a new batch to the verifier
+        fn add_batch(&mut self, batch: Self::Batch) -> Result<(), InternalError> {
+            self.current_value = Some(batch.value);
+            Ok(())
+        }
+
+        /// Finalize the verification of the batches, returning the execution results of batches
+        /// that have completed execution.
+        fn finalize(&mut self) -> Result<Vec<Self::ExecutionResult>, InternalError> {
+            Ok(vec![TestBatchExecutionResult {
+                value: self
+                    .current_value
+                    .as_ref()
+                    .ok_or_else(|| InternalError::with_message("no value set".into()))?
+                    .clone(),
+            }])
+        }
+
+        /// Cancel exeuction of batches, discarding all excution results
+        fn cancel(&mut self) -> Result<(), InternalError> {
+            self.current_value = None;
+            Ok(())
+        }
+    }
+
+    struct TestBatchVerifierFactory {}
+
+    impl BatchVerifierFactory for TestBatchVerifierFactory {
+        type Batch = TestBatch;
+        type Context = Arc<Mutex<TestContext>>;
+        type ExecutionResult = TestBatchExecutionResult;
+
+        // allow type complexity here because of the use of associated types
+        #[allow(clippy::type_complexity)]
+        /// Start execution of batches in relation to a specific context by
+        /// returning a `BatchVerifier`
+        fn start(
+            &mut self,
+            _context: Self::Context,
+        ) -> Result<
+            Box<
+                dyn BatchVerifier<
+                    Batch = Self::Batch,
+                    Context = Self::Context,
+                    ExecutionResult = Self::ExecutionResult,
+                >,
+            >,
+            InternalError,
+        > {
+            Ok(Box::new(TestBatchVerifier {
+                current_value: None,
+            }))
+        }
+    }
+
+    struct BatchIter {
+        batches: Vec<TestBatch>,
+    }
+
+    impl PendingBatches<TestBatch> for BatchIter {
+        fn next(&mut self) -> Result<Option<TestBatch>, InternalError> {
+            Ok(self.batches.pop())
+        }
+    }
+}

--- a/libsawtooth/src/publisher/mod.rs
+++ b/libsawtooth/src/publisher/mod.rs
@@ -20,10 +20,14 @@
 mod batch;
 mod batch_verifier;
 mod context;
+mod factory;
+mod handler;
 mod message;
 mod pending_batches;
 
 pub use batch::Batch;
 pub use batch_verifier::{BatchExecutionResult, BatchVerifier, BatchVerifierFactory};
 pub use context::PublishingContext;
+pub use factory::PublishFactory;
+pub use handler::PublishHandle;
 pub use pending_batches::PendingBatches;

--- a/libsawtooth/src/publisher/pending_batches.rs
+++ b/libsawtooth/src/publisher/pending_batches.rs
@@ -15,15 +15,13 @@
  * ------------------------------------------------------------------------------
  */
 
-//! Contains traits and struct required publishing new artifacts
+//! Contains a trait for getting pending batches
 
-mod batch;
-mod batch_verifier;
-mod context;
-mod message;
-mod pending_batches;
+use crate::error::InternalError;
 
-pub use batch::Batch;
-pub use batch_verifier::{BatchExecutionResult, BatchVerifier, BatchVerifierFactory};
-pub use context::PublishingContext;
-pub use pending_batches::PendingBatches;
+use super::Batch;
+
+/// Return the next `Batch` that should be executed
+pub trait PendingBatches<B: Batch>: Send {
+    fn next(&mut self) -> Result<Option<B>, InternalError>;
+}


### PR DESCRIPTION
The publisher is in charge of returning the next item to publish
to the Supervisor and consensus. It will return the Artifact to
agree upon, for example a block or a batch execution result.
The publisher needs to be able to continue to publish until it is
told to stop. The work may be canceled if the building Artifact
will no longer be valid, for example if the current chain head has changed.

The following design is done with the goal of defining Rust structs that
takes a set of traits. These traits would allow the same publisher structs
 to be used in any situation (e.i. Scabbard or Sawtooth).

A supervisor will use a PublishFactory that will be used to start
the execution. Once started, a PublishHandle is returned that is used
to finish or cancel the publishing.