### PR TITLE
Add missing feature dependency

### DIFF
--- a/libsawtooth/Cargo.toml
+++ b/libsawtooth/Cargo.toml
@@ -225,7 +225,7 @@ transact-workload-runner = [
   "reqwest",
   "serde",
 ]
-transaction-receipt-store = []
+transaction-receipt-store = ["transact"]
 validator-internals = [
   "cbor-codec",
   "cylinder",


### PR DESCRIPTION
This change adds a missing feature dependency to provide the base transact protocol structs when the "transaction-receipt-store" feature is enabled with no-default-features.