### PR TITLE
Fix contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@ Hyperledger Sawtooth is Apache 2.0 licensed and accepts contributions via
 [GitHub](https://github.com/hyperledger/sawtooth-core) pull requests.
 
 Please see
-[Contributing](https://sawtooth.hyperledger.org/docs/core/releases/latest/community/contributing.html)
+[Contributing](https://sawtooth.hyperledger.org/community/contributing.html)
 in the Sawtooth documentation for information on how to contribute and the guidelines for contributions.
 

--- a/libsawtooth/build.rs
+++ b/libsawtooth/build.rs
@@ -57,14 +57,14 @@ fn main() {
         .expect("Unable to write mod file");
 
     protoc_rust::Codegen::new()
-        .out_dir(&dest_path.to_str().expect("Invalid proto destination path"))
+        .out_dir(dest_path.to_str().expect("Invalid proto destination path"))
         .inputs(
             &proto_src_files
                 .iter()
                 .map(|a| a.as_ref())
                 .collect::<Vec<&str>>(),
         )
-        .includes(&["src", "protos"])
+        .includes(["src", "protos"])
         .customize(Customize::default())
         .run()
         .expect("unable to run protoc");


### PR DESCRIPTION
Commit fixing the clippy warnings build issue [squashed](https://github.com/hyperledger/sawtooth-lib/commit/8f642a45ee9bbddb29b23341400825d4faed01fc) into this commit

---
Signed-off-by: Joseph Livesey [joseph@blockchaintp.com](mailto:joseph@blockchaintp.com)