### PR TITLE
Initialize publish env with build env items

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,5 +69,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Display envvars
+        run: env
+
+      - name: Print rustc version
+        run: rustc --version
+
+      - name: Install wasm32-unknown-unknown
+        run: rustup target add wasm32-unknown-unknown
+
+      - name: Install apt packages
+        run: sudo apt install -y libzmq3-dev
+
+      - name: Install protoc
+        run: |
+          curl -OLsS https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip
+          unzip protoc-3.5.1-linux-x86_64.zip -d protoc3
+          rm protoc-3.5.1-linux-x86_64.zip
+
       - name: Publish release to crates
         run: CARGO_REGISTRY_TOKEN=${{ secrets.CARGO_TOKEN }} cargo publish --manifest-path=libsawtooth/Cargo.toml


### PR DESCRIPTION
When calling 'cargo publish', we need some subset of the setup from the build environment, since cargo will build a local test. So, do the same setup there.
