### PR TITLE
Remove explicit call to .into_iter()

### DIFF
--- a/libsawtooth/src/hashlib.rs
+++ b/libsawtooth/src/hashlib.rs
@@ -27,7 +27,7 @@ pub fn sha256_digest_strs(strs: &[String]) -> Vec<u8> {
         hasher.update(item.as_bytes());
     }
     let mut bytes = Vec::new();
-    bytes.extend(hasher.finalize().into_iter());
+    bytes.extend(hasher.finalize());
     bytes
 }
 


### PR DESCRIPTION
Fixes lint in introduced in 1.72 rust