### PR TITLE
Fix bug in commit_store get_batch_by_transaction

### DIFF
--- a/libsawtooth/src/journal/commit_store.rs
+++ b/libsawtooth/src/journal/commit_store.rs
@@ -324,7 +324,7 @@ impl CommitStore {
                     .batches()
                     .iter()
                     .find(|batch| {
-                        !batch
+                        batch
                             .transactions()
                             .iter()
                             .any(|txn| txn.header_signature() == transaction_id)

--- a/libsawtooth/src/transact/database/lmdb.rs
+++ b/libsawtooth/src/transact/database/lmdb.rs
@@ -533,9 +533,9 @@ mod tests {
         })
     }
 
-    fn run_test<T>(test: T) -> ()
+    fn run_test<T>(test: T)
     where
-        T: FnOnce(&str) -> () + panic::UnwindSafe,
+        T: FnOnce(&str) + panic::UnwindSafe,
     {
         let dbpath = temp_db_path();
 


### PR DESCRIPTION
This PR fixes a bug in the `sawtooth_validator::journal::commit_store::CommitStore`'s `get_batch_by_transaction` method, which heretofore returned the first batch that does **not** contain the provided `transaction_id` argument without any error. 

[Original work](https://github.com/blockchaintp/sawtooth-core/pull/31)
See also: [hyperledger/sawtooth-core PR#2458](https://github.com/hyperledger/sawtooth-core/pull/2458)

---
Signed-off-by: Joseph Livesey [jlivesey@gmail.com](mailto:jlivesey@gmail.com)